### PR TITLE
Revision of sections 1-3

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -46,7 +46,7 @@ As is well known many of the problems associated with Big Bang cosmology which i
 the flatness problem, the horizon problem, and the monopole problem are resolved by inflation~\cite{Guth:1980zm, Starobinsky:1980te, Linde:1981mu, Albrecht:1982wi, Sato:1980yn, Linde:1983gd}.
 Quantum fluctuations at the time of horizon exit carry significant information regarding specifics of the inflationary model~\cite{Mukhanov:1981xt, Hawking:1982cz, Starobinsky:1982ee, Guth:1982ec, Bardeen:1983qw, Cheung:2007st} which can be extracted from cosmic microwave background (CMB) radiation anisotropy.
 The data from the Planck experiment~\cite{Adam:2015rua, Ade:2015lrj, Array:2015xqh} has helped constrain inflation models excluding some and narrowing down the parameter space of others.
-One such model is so called natural inflation based on a $U(1)$ shift symmetry which is described by a simple potential~\cite{Freese:1990rb, Adams:1992bn} $V\left(a\right) = \Lambda^4 \left(1 - \cos\left(\frac{b}{f}\right)\right)$, where $a$ is the axion field and $f$ is the axion decay constant.
+One such model is so-called natural inflation based on a $U(1)$ shift symmetry which is described by a simple potential~\cite{Freese:1990rb, Adams:1992bn} $V\left(a\right) = \Lambda^4 \left(1 - \cos\left(\frac{b}{f}\right)\right)$, where $a$ is the axion field and $f$ is the axion decay constant.
 In this case, consistency with Planck data requires the axion decay constant to be significantly greater than the Planck mass $M_\text{P}$.
 However, an axion decay constant larger than the Planck mass is undesirable since a global symmetry is not preserved by quantum gravity unless it has a gauge origin.
 Additionally string theory prefers the axion decay constant to lie below $M_\text{P}$~\cite{Banks:2003sx, Svrcek:2006yi}.
@@ -56,10 +56,12 @@ A procedure for resolving the axion decay constant problem was proposed in~\cite
 One element of this analysis relies on a decomposition of the potential into a fast-roll and a slow-roll parts where the slow roll is controlled only by the inflaton field while the remaining fields enter in fast roll and are not relevant for inflation~\cite{Nath:2017ihp} (for a review of inflation in supersymmetric theories see, e.g.,~\cite{Nath:2016qzm}).
 An analysis within this model shows that one can obtain spectral indices as well as the ratio of the tensor to the scalar power spectrum consistent with the Planck data~\cite{Adam:2015rua, Ade:2015lrj, Array:2015xqh}.
 
-The outline of the rest of the paper is as follows: In section \ref{sec:Alignment} we give a brief introduction to the alignment mechanism.
+The outline of the rest of the paper is as follows.
+In section \ref{sec:Alignment} we give a brief introduction to the alignment mechanism.
 In section \ref{sec:CoherentEnhancement} we discuss the coherent enhancement mechanism when the potential consists of a superposition of cosines which is typically the case for axionic potentials we consider.
 We exhibit the coherent enhancement in various settings.
-Thus in section \ref{sec:Supersymmetry} we discuss this mechanism in globally supersymmetric models, in section \ref{sec:Supergravity} for supergravity models, in section \ref{sec:KKLT} for KKLT, in section \ref{sec:LVS} for the Large Volume Scenario, and in section \ref{sec:DBI} for the Dirac-Born-Infeld case.
+Thus in section \ref{sec:Supersymmetry} we discuss this mechanism in globally supersymmetric models, in section \ref{sec:Supergravity} for supergravity models, in section \ref{sec:KKLT} for KKLT, in section \ref{sec:LVS} for the Large Volume Scenario.
+In section \ref{sec:DBI}, we discuss the Dirac-Born-Infeld case, in which inflation occurs due to a different mechanism, however, an effective decay constant $f_e$ can still be defined based on inflation dynamics.
 Conclusions are given in section \ref{sec:Conclusion}.
 Some relevant papers related to this work can be found in \cite{BlancoPillado:2006he, Conlon:2005jm, Ben-Dayan:2014lca, Gao:2014uha}.
 

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -29,15 +29,15 @@
 Models of axion inflation based on a single cosine potential require the axion decay constant to be super Planckian in size.
 However, a super Plankian axion decay constant is disfavored in quantum gravity and in strings.
 Here we propose a coherent enhancement mechanism which can produce an effective axion decay which is super Planckian even when the true axion decay constant is sub Planckian.
-We discuss the utility of the coherent enhancement mechanism for a variety of axion potentials originating in supersymmetry, supergravity and strings.
+We discuss the utility of the coherent enhancement mechanism for a variety of axion potentials originating in supersymmetry, supergravity, and strings.
 The coherent enhancement mechanism allows one to reduce an inflation model with an arbitrary potential to an effective model of natural inflation, i.e. with a single cosine, by expanding the potential near an inflationary point, and matching the expansion coefficients to those of natural inflation.
 We demonstrate that this approach can predict the number of e-foldings in a given inflation model without the need for numerical simulation.
 Further we show that the effective decay constant $f_e$ can be directly related to the spectral indices so that $f_e = 1 / \sqrt{1 - n_s - r / 4}$ in Planck units where $n_s$ is the spectral index for curvature perturbations and $r$ is the ratio of the power spectrum of tensor perturbations and curvature perturbations.
 Thus the current data on $n_s$ and $r$ constrains the effective axion decay constant so that $4.6 \leq f_e \leq 11$ at $95\%$ CL.
-Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 10$ in units of Planck mass in axion cosmology for any potential based model which produces successful inflation.
+Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 10$ in units of Planck mass in axion cosmology for any potential-based model which produces successful inflation.
 The coherent enhancement mechanism for the generation of an effective $f_e > 1$ while the true axion decay constant $f < 1$ is discussed.
 We illustrate the coherent enhancement in several settings: globally supersymmetric models, supergravity models, in string setting including KKLT and Large Volume Scenario, and Dirac-Born-Infeld models.
-In each case all the moduli are stabilized and the inflationary model consistent with astrophysical observations with $f_e > 1$ and the true axion decay constant $f < 1$ in Planck units.
+In each case, all the moduli are stabilized and the inflationary model consistent with astrophysical observations with $f_e > 1$ and the true axion decay constant $f < 1$ in Planck units.
 \newpage
 
 \section{Introduction \label{sec:Introduction}}
@@ -46,10 +46,10 @@ the flatness problem, the horizon problem, and the monopole problem are resolved
 Quantum fluctuations at the time of horizon exit carry significant information regarding specifics of the inflationary model~\cite{Mukhanov:1981xt, Hawking:1982cz, Starobinsky:1982ee, Guth:1982ec, Bardeen:1983qw, Cheung:2007st} which can be extracted from cosmic microwave background (CMB) radiation anisotropy.
 The data from the Planck experiment~\cite{Adam:2015rua, Ade:2015lrj, Array:2015xqh} has helped constrain inflation models excluding some and narrowing down the parameter space of others.
 One such model is so called natural inflation based on a $U(1)$ shift symmetry which is described by a simple potential~\cite{Freese:1990rb, Adams:1992bn} $V\left(a\right) = \Lambda^4 \left(1 - \cos\left(\frac{b}{f}\right)\right)$, where $a$ is the axion field and $f$ is the axion decay constant.
-In this case consistency with Planck data requires the axion decay constant to be significantly greater than the Planck mass $M_\text{P}$.
+In this case, consistency with Planck data requires the axion decay constant to be significantly greater than the Planck mass $M_\text{P}$.
 However, an axion decay constant larger than the Planck mass is undesirable since a global symmetry is not preserved by quantum gravity unless it has a gauge origin.
 Additionally string theory prefers the axion decay constant to lie below $M_\text{P}$~\cite{Banks:2003sx, Svrcek:2006yi}.
-It turns out that the reduction of the decay constant poses a problem, and several suggestions exist regarding its resolution such as the so called alignment mechanism~\cite{Kim:2004rp, Long:2014dta}.
+It turns out that the reduction of the decay constant poses a problem, and several suggestions exist regarding its resolution such as the so-called alignment mechanism~\cite{Kim:2004rp, Long:2014dta}.
 
 A procedure for resolving the axion decay constant problem was proposed in~\cite{Nath:2017ihp}.
 One element of this analysis relies on a decomposition of the potential into a fast-roll and a slow-roll parts where the slow roll is controlled only by the inflaton field while the remaining fields enter in fast roll and are not relevant for inflation~\cite{Nath:2017ihp} (for a review of inflation in supersymmetric theories see, e.g.,~\cite{Nath:2016qzm}).
@@ -167,12 +167,12 @@ The current experimental limits from Planck experiment at $k_0 = 0.05\,{\rm Mpc}
   \end{aligned}
 \end{equation}
 while $n_t\left(k_0\right)$ is currently not constrained.
-Using this data we find model independent bounds on the effective axionic decay constant so that
+Using this data we find model-independent bounds on the effective axionic decay constant so that
 \begin{equation}
   4.6 \leq f_e \leq 11\, \left(95\%\, {\rm CL}\right)\,.
 \end{equation}
 
-Next we discuss CEM for a superposition of cosine functions and show how the effective axion decay constant becomes super-Planckian even though the true decay constant is sub-Plankian.
+Next, we discuss CEM for a superposition of cosine functions and show how the effective axion decay constant becomes super-Planckian even though the true decay constant is sub-Plankian.
 As a specific simple example let us consider a potential of the form
 \begin{equation} \label{eq:cosineSumPotential}
   V = \sum_{k = 1}^n \Lambda_k^4 \left(1 - \cos\left(\frac{k\phi}{f}\right)\right)\,.
@@ -188,7 +188,7 @@ One notices that there is cancellation between the odd and even sums in the deno
 Since the enhancement occurs as a consequence of the sum of several terms one may call this a ``coherent enhancement mechanism''.
 
 \section{Coherent enhancement mechanism in supersymmetry models \label{sec:Supersymmetry}}
-In this section and the following sections we will discuss coherent enhancement mechanism in a variety of inflation models consistent with the current astrophysical data from the Planck experiment.
+In this section and the following sections we will discuss the coherent enhancement mechanism in a variety of inflation models consistent with the current astrophysical data from the Planck experiment.
 As mentioned in the introduction these models are in a variety of settings: global supersymmetry, supergravity, KKLT, LVS and DBI.
 In this section we focus on the globally supersymmetric models.
 For the analysis here we consider two chiral fields $\Phi_i, i = 1, 2$ charged under a global $U\left(1\right)$ transformation, and two other fields $\bar\Phi_i, i = 1, 2$ that are oppositely charged.
@@ -400,7 +400,7 @@ where $C_k$ are given by
 % TODO(maxitg): Simulation part needs to be added here.
 
 \section{Coherent axion enhancement in KKLT \label{sec:KKLT}}
-We wish to discuss coherent enhancement of the decay constant in KKLT~\cite{Kachru:2003aw}.
+We wish to discuss the coherent enhancement of the decay constant in KKLT~\cite{Kachru:2003aw}.
 The scalar potential of the theory is as given by Eq.~(\ref{eq:supergravity:potential}) and Eq.~(\ref{eq:supergravity:DW}).
 In the KKLT analysis we consider a K\"ahler potential with a single modulus $T$ so that
 \begin{equation} \label{eq:KKLT:kahler}

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -68,10 +68,10 @@ An early work using QCD axions is the so-called natural inflation where the infl
   V(a) = \Lambda^4 \left(1 - \cos\left(\frac{\phi}{f}\right)\right)\,,
 \end{equation}
 $f$ is axion decay constant.
-For a QCD axion $10^9 < f < 10^{12}$ GeV.
+For a QCD axion $10^9 < f < 10^{12}$ GeV~\cite{Svrcek:2006yi}.
 For inflation one requires $f > 7 M_\text{P}$~\cite{Ade:2015lrj}.
 However, $f > M_\text{P}$ is undesirable since global symmetry is not preserved by quantum gravity unless it has a gauge origin.
-Further, string theory prefers $f$ in the range $\left(10^{16} - 10^{18}\right)$ GeV.
+Further, string theory prefers $f$ in the range $\left(10^{16} - 10^{18}\right)$ GeV~\cite{Svrcek:2006yi}.
 Thus to get a successful natural inflation is difficult.
 
 One suggestion to realize $f < M_\text{P}$ is to use two axions and the alignment mechanism to achieve a flat direction.

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -74,19 +74,21 @@ However, $f > M_\text{P}$ is undesirable since global symmetry is not preserved 
 Further, string theory prefers $f$ in the range $\left(10^{16} - 10^{18}\right)$ GeV~\cite{Svrcek:2006yi}.
 Thus to get a successful natural inflation is difficult.
 
-One suggestion to realize $f < M_\text{P}$ is to use two axions and the alignment mechanism to achieve a flat direction.
+One suggestion to realize $f < M_\text{P}$ is to use two axions and the alignment mechanism to achieve a flat direction~\cite{Long:2014dta}.
 For a model with two axions $\phi_1$ and $\phi_2$ one considers a potential
 \begin{equation} \label{eq:alignmentPotential}
   V(\phi)
     = \Lambda^4_1 \left[1 - \cos\left(\frac{\phi_1}{f_1} + \frac{\phi_2}{f_2}\right)\right]
     + \Lambda^4_2 \left[1 - \cos\left(\frac{\phi_1}{f_3} + \frac{\phi_2}{f_4}\right)\right]\,.
 \end{equation}
-Constraint for a flat direction:
+Then, one takes a constraint for a flat direction:
 \begin{equation}
-  \frac{f_1}{f_2} = \frac{f_3}{f_4}\,.
+  \frac{f_1}{f_2} = \frac{f_3}{f_4}\,,
 \end{equation}
-However, to get the potential of Eq.~(\ref{eq:alignmentPotential}) one starts out by assuming that the same field has different decay constants, i.e., $\phi_1$ is associated with $f_1$ and $f_3$ and $\phi_2$ is associated with $f_2$ and $f_3$.
-Here we discuss a new mechanism which can produce an effective decay constant that enters in inflation which is much larger than the true axion decay constant.
+and considers small corrections to that constraint to produce a light inflaton.
+However, this approach requires an assumption that the same field has different decay constants, i.e., $\phi_1$ is associated with $f_1$ and $f_3$ and $\phi_2$ is associated with $f_2$ and $f_3$.
+Here, we discuss a different mechanism that only relies on integer coefficients inside of cosines, and uses the alignment of coefficients in front of cosines to produce an effective axion decay constant that is much larger than the true decay constant.
+Further, we discuss how such alignment may arise from more fundamental supersymmetry, supergravity and string models.
 
 \section{General Analysis of Coherent Enhancement Mechanism \label{sec:CoherentEnhancement}}
 Before we discuss the Coherent Enhancement Mechanism (CEM) we derive a relation that gives the effective axion decay constant directly in terms of the inflationary parameters and in terms of the experimentally measurable spectral indices.

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -28,16 +28,17 @@
 \textbf{Abstract:}
 Models of axion inflation based on a single cosine potential require the axion decay constant to be super Planckian in size.
 However, a super Plankian axion decay constant is disfavored in quantum gravity and in strings.
-Here we propose a coherent enhancement mechanism which can produce an effective axion decay which is super Planckian even when the true axion decay constant is sub Planckian.
-We discuss the utility of the coherent enhancement mechanism for a variety of axion potentials originating in supersymmetry, supergravity, and strings.
+Here we propose a coherent enhancement mechanism which can produce an effective axion decay constant which is super Planckian even if the true decay constant is sub Planckian.
+We discuss the utility of this mechanism for a variety of axion potentials originating in supersymmetry, supergravity, and strings.
 The coherent enhancement mechanism allows one to reduce an inflation model with an arbitrary potential to an effective model of natural inflation, i.e. with a single cosine, by expanding the potential near an inflationary point, and matching the expansion coefficients to those of natural inflation.
 We demonstrate that this approach can predict the number of e-foldings in a given inflation model without the need for numerical simulation.
-Further we show that the effective decay constant $f_e$ can be directly related to the spectral indices so that $f_e = 1 / \sqrt{1 - n_s - r / 4}$ in Planck units where $n_s$ is the spectral index for curvature perturbations and $r$ is the ratio of the power spectrum of tensor perturbations and curvature perturbations.
-Thus the current data on $n_s$ and $r$ constrains the effective axion decay constant so that $4.6 \leq f_e \leq 11$ at $95\%$ CL.
-Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 10$ in units of Planck mass in axion cosmology for any potential-based model which produces successful inflation.
-The coherent enhancement mechanism for the generation of an effective $f_e > 1$ while the true axion decay constant $f < 1$ is discussed.
-We illustrate the coherent enhancement in several settings: globally supersymmetric models, supergravity models, in string setting including KKLT and Large Volume Scenario, and Dirac-Born-Infeld models.
-In each case, all the moduli are stabilized and the inflationary model consistent with astrophysical observations with $f_e > 1$ and the true axion decay constant $f < 1$ in Planck units.
+Further we show that the effective decay constant $f_e$ can be directly related to the spectral indices so that $f_e = M_\text{P} / \sqrt{1 - n_s - r / 4}$ where $n_s$ is the spectral index for curvature perturbations and $r$ is the ratio of the power spectrum of tensor perturbations and curvature perturbations.
+Thus the current data on $n_s$ and $r$ constrains the effective axion decay constant so that $4.6 \leq f_e / M_\text{P} \leq 11$ at $95\%$ CL.
+Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 11 M_\text{P}$ in units of Planck mass in axion cosmology for any potential-based model which produces successful inflation.
+The coherent enhancement mechanism for the generation of an effective $f_e > M_\text{P}$ while the true axion decay constant $f < M_\text{P}$ is discussed.
+We illustrate the coherent enhancement in several settings: globally supersymmetric models, supergravity models, and in string setting including KKLT and Large Volume Scenario.
+We also show that $f_e$ based on inflation dynamics can be defined for non-potential-based models, and consider a Dirac-Born-Infeld model as an example.
+In each case, all the moduli are stabilized and the inflationary model consistent with astrophysical observations with $f_e > M_\text{P}$ and the true axion decay constant $f < M_\text{P}$.
 \newpage
 
 \section{Introduction \label{sec:Introduction}}

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -69,7 +69,7 @@ An early work using QCD axions is the so-called natural inflation where the infl
 \end{equation}
 $f$ is axion decay constant.
 For a QCD axion $10^9 < f < 10^{12}$ GeV.
-For inflation one requires $f > 10 M_\text{P}$.
+For inflation one requires $f > 7 M_\text{P}$~\cite{Ade:2015lrj}.
 However, $f > M_\text{P}$ is undesirable since global symmetry is not preserved by quantum gravity unless it has a gauge origin.
 Further, string theory prefers $f$ in the range $\left(10^{16} - 10^{18}\right)$ GeV.
 Thus to get a successful natural inflation is difficult.
@@ -127,7 +127,7 @@ Now, identifying the expansion coefficients in Eq.~(\ref{eq:naturalInflationSeri
     {{V^\prime}^2\left(\phi_0\right) - V\left(\phi_0\right) V^{\prime\prime}\left(\phi_0\right)}\,.
 \end{equation}
 Here, we are mostly interested in Eq.~(\ref{eq:feFromPotential}), which gives the effective axion decay constant for the potential $V\left(\phi\right)$ near $\phi = \phi_0$.
-Due to the second flatness condition, $\left|\eta_H\right| = \left|V_e^{\prime\prime} / V_e\right| = 1 / \left(2 f_e^2\right) \ll 1$, natural inflation can only generate experimentally consistent observables when $f_e \gg 1$.
+Due to the second flatness condition, $\left|\eta\right| = \left|V_e^{\prime\prime} / V_e\right| = 1 / f_e^2 \ll 1$, natural inflation can only generate experimentally consistent observables when $f_e \gg 1$.
 However, as discussed already the true axion decay constant larger than one is undesirable from considerations of quantum gravity and string theory \cite{Kallosh:1995hi, Banks:2003sx}.
 Coherent Enhancement provides a solution in that the true axion decay constant can be smaller than one while the effective axion decay constant is larger or even much larger than one.
 
@@ -179,10 +179,9 @@ Here let us choose $\phi_0$ where the maximum occurs so that $\frac{\phi}{f} = \
 In this case we get
 \begin{equation} \label{eq:feForCosineSum}
   {f_e} / f = \frac
-    {\sqrt{\sum_{k - odd} \Lambda_k}}
-    {\sqrt{\left[\sum_{k - odd} k^2 \Lambda_k^4 - \sum_{k - even} k^2 \Lambda_k^4\right]}}\,.
+    {\sqrt{\sum_{k \in odd} \Lambda_k^4}}
+    {\sqrt{\sum_{k \in odd} k^2 \Lambda_k^4 - \sum_{k \in even} k^2 \Lambda_k^4}}\,.
 \end{equation}
-Eq.~(\ref{eq:feForCosineSum}) holds in the limit when $\epsilon = 0$ which is, however, typically small.
 One notices that there is cancellation between the odd and even sums in the denominator in Eq.~(\ref{eq:feForCosineSum}) which leads to an enhancement and gives $f_e / f > 1$.
 Since the enhancement occurs as a consequence of the sum of several terms one may call this a ``coherent enhancement mechanism''.
 

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -45,7 +45,7 @@ As is well known many of the problems associated with Big Bang cosmology which i
 the flatness problem, the horizon problem, and the monopole problem are resolved by inflation~\cite{Guth:1980zm, Starobinsky:1980te, Linde:1981mu, Albrecht:1982wi, Sato:1980yn, Linde:1983gd}.
 Quantum fluctuations at the time of horizon exit carry significant information regarding specifics of the inflationary model~\cite{Mukhanov:1981xt, Hawking:1982cz, Starobinsky:1982ee, Guth:1982ec, Bardeen:1983qw, Cheung:2007st} which can be extracted from cosmic microwave background (CMB) radiation anisotropy.
 The data from the Planck experiment~\cite{Adam:2015rua, Ade:2015lrj, Array:2015xqh} has helped constrain inflation models excluding some and narrowing down the parameter space of others.
-One such model is so called natural inflation based on a $U(1)$ shift symmetry which is described by a simple potential~\cite{Freese:1990rb, Adams:1992bn} $V\left(a\right) = \Lambda^4 \left(1 - \cos(\frac{b}{f})\right)$, where $a$ is the axion field and $f$ is the axion decay constant.
+One such model is so called natural inflation based on a $U(1)$ shift symmetry which is described by a simple potential~\cite{Freese:1990rb, Adams:1992bn} $V\left(a\right) = \Lambda^4 \left(1 - \cos\left(\frac{b}{f}\right)\right)$, where $a$ is the axion field and $f$ is the axion decay constant.
 In this case consistency with Planck data requires the axion decay constant to be significantly greater than the Planck mass $M_\text{P}$.
 However, an axion decay constant larger than the Planck mass is undesirable since a global symmetry is not preserved by quantum gravity unless it has a gauge origin.
 Additionally string theory prefers the axion decay constant to lie below $M_\text{P}$~\cite{Banks:2003sx, Svrcek:2006yi}.
@@ -65,7 +65,7 @@ Some relevant papers related to this work can be found in \cite{BlancoPillado:20
 \section{Alignment mechanism \label{sec:Alignment}}
 An early work using QCD axions is the so-called natural inflation where the inflation potential is of the form
 \begin{equation} \label{eq:naturalInflationPotential}
-  V(a) = \Lambda^4 \left(1 - \cos(\frac{\phi}{f})\right)\,,
+  V(a) = \Lambda^4 \left(1 - \cos\left(\frac{\phi}{f}\right)\right)\,,
 \end{equation}
 $f$ is axion decay constant.
 For a QCD axion $10^9 < f < 10^{12}$ GeV.
@@ -85,18 +85,18 @@ Constraint for a flat direction:
 \begin{equation}
   \frac{f_1}{f_2} = \frac{f_3}{f_4}\,.
 \end{equation}
-However, the potential of Eq.~(\ref{eq:alignmentPotential}) appears it startes out by assuming that the same field has different decay constants, i.e., $\phi_1$ is associated with $f_1$ and $f_3$ and $\phi_2$ is associated with $f_2$ and $f_3$.
+However, to get the potential of Eq.~(\ref{eq:alignmentPotential}) one starts out by assuming that the same field has different decay constants, i.e., $\phi_1$ is associated with $f_1$ and $f_3$ and $\phi_2$ is associated with $f_2$ and $f_3$.
 Here we discuss a new mechanism which can produce an effective decay constant that enters in inflation which is much larger than the true axion decay constant.
 
 \section{General Analysis of Coherent Enhancement Mechanism \label{sec:CoherentEnhancement}}
-Before we discuss the Coherent Enhancement Mechanism (CEM) we derive a relation what gives the effective axion decay constant directly in terms of the inflationary parameters and in terms of the experimentally measurable spectral indices.
-Thus we consider a canonical Lagrangian of the form with a
+Before we discuss the Coherent Enhancement Mechanism (CEM) we derive a relation that gives the effective axion decay constant directly in terms of the inflationary parameters and in terms of the experimentally measurable spectral indices.
+Thus we consider a canonical Lagrangian of the form
 \begin{equation}
   \mathcal{L}\left(\phi, \dot{\phi}\right) = \frac{1}{2}{\dot{\phi}}^2 - V\left(\phi\right)\,.
 \end{equation}
 
-Assuming the kinetic in canonically normalized in each case, it is sufficient to have $V\left(\phi\right) \approx V_{e}\left(\phi\right)$ where $V_{e}\left(\phi\right)$ is given by Eq.~(\ref{eq:naturalInflationPotential}) at $\phi \approx \phi_0$ to have similar evolution of the field and the scale factor near $\phi \sim \phi_0$.
-Using this observation, we can express the parameters of natural Inflation $\Lambda$ and $f_e$ in terms of various order derivatives of $V\left(\phi\right)$.
+Assuming the kinetic term is canonically normalized in each case, it is sufficient to have $V\left(\phi\right) \approx V_{e}\left(\phi\right)$ where $V_{e}\left(\phi\right)$ is given by Eq.~(\ref{eq:naturalInflationPotential}) at $\phi \approx \phi_0$ to have similar evolution of the field and the scale factor near $\phi \sim \phi_0$.
+Using this observation, we can express the parameters of natural inflation $\Lambda$ and $f_e$ in terms of various order derivatives of $V\left(\phi\right)$.
 To do that, first, expand $V_{e}$ near $\phi_0$ to the second order so that
 \begin{equation} \label{eq:naturalInflationSeries}
   \begin{aligned}
@@ -127,9 +127,9 @@ Now, identifying the expansion coefficients in Eq.~(\ref{eq:naturalInflationSeri
     {{V^\prime}^2\left(\phi_0\right) - V\left(\phi_0\right) V^{\prime\prime}\left(\phi_0\right)}\,.
 \end{equation}
 Here, we are mostly interested in Eq.~(\ref{eq:feFromPotential}), which gives the effective axion decay constant for the potential $V\left(\phi\right)$ near $\phi = \phi_0$.
-Due to second flatness condition, $\left|\eta_H\right| = \left|V_e^{\prime\prime} / V_e\right| = 1 / \left(2 f_e^2\right) \ll 1$, Natural Inflation can only generate experimentally consistent observables when $f_e \gg 1$.
+Due to the second flatness condition, $\left|\eta_H\right| = \left|V_e^{\prime\prime} / V_e\right| = 1 / \left(2 f_e^2\right) \ll 1$, natural inflation can only generate experimentally consistent observables when $f_e \gg 1$.
 However, as discussed already the true axion decay constant larger than one is undesirable from considerations of quantum gravity and string theory \cite{Kallosh:1995hi, Banks:2003sx}.
-Coherent Enhancement provides a solution in that the true axion decay constants can be smaller than one while the effective axion decay constant is larger or even much larger than one.
+Coherent Enhancement provides a solution in that the true axion decay constant can be smaller than one while the effective axion decay constant is larger or even much larger than one.
 
 Finally, it is also possible to express the effective decay constant in terms of slow-roll inflation parameters $\epsilon$ and $\eta$ defined as
 \begin{equation} \label{eq:epsEtaFromPotential}
@@ -155,7 +155,7 @@ The spectral indices $n_s$ and $n_t$ are related to the inflationary parameters 
 \end{equation}
 We can thus eliminate $\eta$ and $\epsilon$ in favor of $n_s$ and $r$ and get
 \begin{equation}
-  f_e = \frac{1}{\sqrt{1 - n_s - \frac{r}{4}}}\,.
+  f_e = \frac{1}{\sqrt{1 - n_s - r / 4}}\,.
 \end{equation}
 The current experimental limits from Planck experiment at $k_0 = 0.05\,{\rm Mpc}^{-1}$ are as follows~\cite{Adam:2015rua, Ade:2015lrj, Array:2015xqh}
 \begin{equation} \label{data}
@@ -182,7 +182,7 @@ In this case we get
     {\sqrt{\sum_{k - odd} \Lambda_k}}
     {\sqrt{\left[\sum_{k - odd} k^2 \Lambda_k^4 - \sum_{k - even} k^2 \Lambda_k^4\right]}}\,.
 \end{equation}
-Eq.~(\ref{eq:feForCosineSum}) holds in the limit when $\epsilon = 0$ which is, however, is typically small.
+Eq.~(\ref{eq:feForCosineSum}) holds in the limit when $\epsilon = 0$ which is, however, typically small.
 One notices that there is cancellation between the odd and even sums in the denominator in Eq.~(\ref{eq:feForCosineSum}) which leads to an enhancement and gives $f_e / f > 1$.
 Since the enhancement occurs as a consequence of the sum of several terms one may call this a ``coherent enhancement mechanism''.
 

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -68,9 +68,9 @@ Some relevant papers related to this work can be found in \cite{BlancoPillado:20
 \section{Alignment mechanism \label{sec:Alignment}}
 An early work using QCD axions is the so-called natural inflation where the inflation potential is of the form
 \begin{equation} \label{eq:naturalInflationPotential}
-  V(a) = \Lambda^4 \left(1 - \cos\left(\frac{\phi}{f}\right)\right)\,,
+  V\left(\phi\right) = \Lambda^4 \left(1 - \cos\left(\frac{\phi}{f}\right)\right)\,,
 \end{equation}
-$f$ is axion decay constant.
+and $f$ is the axion decay constant.
 For a QCD axion $10^9 < f < 10^{12}$ GeV~\cite{Svrcek:2006yi}.
 For inflation one requires $f > 7 M_\text{P}$~\cite{Ade:2015lrj}.
 However, $f > M_\text{P}$ is undesirable since global symmetry is not preserved by quantum gravity unless it has a gauge origin.
@@ -89,8 +89,8 @@ Then, one takes a constraint for a flat direction:
   \frac{f_1}{f_2} = \frac{f_3}{f_4}\,,
 \end{equation}
 and considers small corrections to that constraint to produce a light inflaton.
-However, this approach requires an assumption that the same field has different decay constants, i.e., $\phi_1$ is associated with $f_1$ and $f_3$ and $\phi_2$ is associated with $f_2$ and $f_3$.
-Here, we discuss a different mechanism that only relies on integer coefficients inside of cosines, and uses the alignment of coefficients in front of cosines to produce an effective axion decay constant that is much larger than the true decay constant.
+However, this approach requires an assumption that the same field is associated with multiple decay constants, i.e., $\phi_1$ is associated with $f_1$ and $f_3$, and $\phi_2$ is associated with $f_2$ and $f_3$.
+Here, we discuss a different mechanism that relies on the coefficients in front of cosines instead to produce an effective axion decay constant that is much larger than the true decay constant.
 Further, we discuss how such alignment may arise from more fundamental supersymmetry, supergravity and string models.
 
 \section{General Analysis of Coherent Enhancement Mechanism \label{sec:CoherentEnhancement}}


### PR DESCRIPTION
## Changes

* Fix various typos in the text.
* Fix incorrect Planck constraint on decay constant in natural inflation from 10 to 7, add the reference.
* Fix incorrect equation for slow-roll eta after Eq. (8).
* Fix mistake in Eq. (18), and remove the incorrect statement that it is only true in epsilon -> 0 limit.
* Clarified that DBI inflation mechanism is not coherent enhancement.
* Clarified the difference from alignment mechanism in section 3.