### PR TITLE
KKLT revision and plots

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -502,17 +502,16 @@ We assume the superpotential $W$ where the modulus dependence arises only in the
 where the modulus $T$ appears only in the exponent and where $A_i$ and $q_i$ are assumed real.
 For the K\"ahler potential of Eq.~(\ref{eq:KKLT:kahler}) the scalar potential Eq.~(\ref{eq:supergravity:potential}) takes the form
 \begin{equation}
-  V = e^K K^{T \bar T} \left[
+  V = e^{K / M_\text{P}^2} K^{T \bar T} \left[
     \partial_T W \partial_{\bar T} \bar W +
-    \left(\partial_T K W \partial_{\bar T} \bar W + \partial_{\bar T} K \bar W \partial_T W\right)
+    \frac{1}{M_\text{P}^2}\left(\partial_T K W \partial_{\bar T} \bar W + \partial_{\bar T} K \bar W \partial_T W\right)
   \right]\,.
 \end{equation}
 An explicit computation of $V$ gives
 \begin{equation} \label{eq:KKLT:VslowUnstabilized}
   \begin{aligned}
     V = \frac{1}{6 \tau} &\left[
-        \sum_i A^2_i q^2_i e^{-2 q_i \tau}
-      + 2 \sum_{i > j} A_i A_j q_i q_j e^{-\left(q_i + q_j\right)\tau}
+        \sum_{i, j} A_i A_j q_i q_j e^{-\left(q_i + q_j\right)\tau}
         \cos\left(\left(q_i - q_j\right) \theta\right)\right.\\
     &{}\left. + \frac{3}{\tau} W_0 \sum_i A_i q_i e^{-q_i \tau} \cos\left(q_i \theta\right)
       + \frac{3}{\tau} \sum_{i, j} A_i A_j q_j e^{-\left(q_i + q_j\right) \tau}

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -497,97 +497,73 @@ In the KKLT analysis we consider a K\"ahler potential with a single modulus $T$ 
 where we may decompose $T$ so that $T = \tau + i \theta$.
 We assume the superpotential $W$ where the modulus dependence arises only in the non-perturbative terms and we take $W$ to have the form
 \begin{equation} \label{eq:KKLT:W}
-  W = W_0 + \sum_{n = 1}^q A_n e^{-\gamma_n T / M_\text{P}}\,,
+  W = W_0 - A e^{-\pi T / M_\text{P}}\,,
 \end{equation}
-where the modulus $T$ appears only in the exponent and where $A_n$ and $\gamma_n$ are assumed real.
-For the K\"ahler potential of Eq.~(\ref{eq:KKLT:kahler}) the scalar potential Eq.~(\ref{eq:supergravity:potential}) takes the form
+where the modulus $T$ appears only in the exponent and where we assume $A > 0$.
+For the K\"ahler potential of Eq.~(\ref{eq:KKLT:kahler}) the Lagrangian takes the form
 \begin{equation}
-  V = e^{K / M_\text{P}^2} K^{T \bar T} \left[
-    \partial_T W \partial_{\bar T} \bar W +
-    \frac{1}{M_\text{P}^2}\left(
-        \partial_T K W \partial_{\bar T} \bar W
-      + \partial_{\bar T} K \bar W \partial_T W\right)
-  \right]\,.
-\end{equation}
-An explicit computation of $V$ gives
-\begin{equation} \label{eq:KKLT:VslowUnstabilized}
-  \begin{aligned}
-    V = \frac{1}{6 \tau M_\text{P}} &\left[
-        \sum_{n = 1}^q \sum_{m = 1}^q A_n A_m \gamma_n
-          \left(\gamma_m + \frac{3 M_\text{P}}{\tau}\right)
-          e^{-\left(\gamma_n + \gamma_m\right)\tau / M_\text{P}}
-          \cos\left(\left(\gamma_n - \gamma_m\right) \frac{\theta}{M_\text{P}}\right)\right.\\
-        &\left.{}
-      + \frac{3 M_\text{P}}{\tau} W_0
-          \sum_{n = 1}^q A_n \gamma_n e^{-\gamma_n \tau / M_\text{P}}
-          \cos\left(\gamma_n \frac{\theta}{M_\text{P}}\right)
+  \mathcal{L} =
+    - K^{T \bar T} \partial_\mu T \partial^\mu \bar{T}
+    - e^{K / M_\text{P}^2} K^{T \bar T} \left[
+      \partial_T W \partial_{\bar T} \bar W +
+      \frac{1}{M_\text{P}^2}\left(
+          \partial_T K W \partial_{\bar T} \bar W
+        + \partial_{\bar T} K \bar W \partial_T W\right)
     \right]\,.
-  \end{aligned}
 \end{equation}
-To stabilize the modulus $\tau$ we use the condition~\cite{Nath:1983aw}
-\begin{equation} \label{eq:KKLT:stabilization}
-  D_T W = 0\,,
-\end{equation}
-which gives the constraint
-\begin{equation} \label{eq:KKLT:W0}
-  W_0 = -\sum_{n = 1}^q A_n e^{-\gamma_n \tau_0 / M_\text{P}}
-    \left(1 + \frac{2}{3} \gamma_n \frac{\tau_0}{M_\text{P}}\right)\,,
-\end{equation}
-where $\left<T\right> = \tau_0, \left<\theta\right> = 0$.
-Next we expand $T$ around the critical point, i.e., $T = \tau_0 + \tau' + \theta$.
-However, the kinetic energy using $\tau$ and $\theta$ is not canonically normalized and we define the normalized fields $\rho, a$ so that
-\begin{equation} \label{eq:KKLT:rho.a}
-  \rho \equiv \frac{\sqrt{3} M_\text{P}}{\sqrt{2} \tau_0} \tau',
-  ~~~ a \equiv \frac{\sqrt{3} M_\text{P}}{\sqrt{2} \tau_0} \theta\,,
-\end{equation}
-for which the kinetic energy takes the canonical form, i.e, $L_\text{kin} = -\frac{1}{2} \left[\partial_\mu \rho \partial^\mu \rho + \partial_\mu a \partial^\mu a\right]$.
-Using the canonically normalized fields we can define the axion decay constant so that $f = \frac{\sqrt{3} M_\text{P}^2}{\sqrt{2} \tau_0}$.
-
-We further require that the vacuum energy vanishes at the minimum of the potential, and this can be achieved by setting $W = 0$ along with the stability condition Eq.~(\ref{eq:KKLT:stabilization}).
-These conditions lead to the constraint
-\begin{equation} \label{eq:KKLT:zeroVacuumConstraint}
-  \sum_{n = 1}^q A_n \gamma_n e^{-\gamma_n \tau_0 / M_\text{P}} = 0\,.
-\end{equation}
-The imposition of Eqs.~(\ref{eq:KKLT:stabilization}, \ref{eq:KKLT:zeroVacuumConstraint}) would lead to moduli stabilization and vanishing of the vacuum energy at the end of inflation.
-For our simulation we solve these constraints for $A_1$ and $A_2$, and we vary $W_0$ and $f$ instead.
-
-Specifically, we take $q = 3$, in which case we get the following potential
-\begin{equation} \label{eq:KKLT:Vslow}
+An explicit computation then gives
+\begin{equation} \label{eq:KKLT:LslowUnnormalized}
   \begin{aligned}
-    V = M_\text{P}^4 &\left(
-        \frac{f^2}{M_\text{P}^2} \frac{W_0}{M_\text{P}^3} \sum_{n = 1}^3 C_n
-          \left(1 - \cos\left(\frac{\gamma_n a}{f}\right)\right)\right.\\
-      &~~~~~~{} \left.
-      + \frac{f}{M_\text{P}} \sum_{n = 1}^3 \sum_{m = n + 1}^3 C_{n m}
-          \left(1 - \cos\left(\frac{\left(\gamma_n - \gamma_m\right) a}{f}\right)\right)\right)\,,
+    \mathcal{L} =
+      &- \frac{3 M_\text{P}^2}{4 \tau^2} \left(
+          \partial_\mu \tau \partial^\mu \tau + \partial_\mu \theta \partial^\mu \theta\right)\\
+      &- M_\text{P}^4 \frac{\pi}{2} \frac{M_\text{P}}{\tau} \left(
+            \left(\frac{\pi}{3} + \frac{M_\text{P}}{\tau}\right)
+              e^{-2 \pi \tau / M_\text{P}}
+              \frac{A^2}{M_\text{P}^6}
+          - \frac{M_\text{P}}{\tau}
+              e^{-\pi \tau / M_\text{P}}
+              \cos\left(\pi \frac{\theta}{M_\text{P}}\right)
+              \frac{A W_0}{M_\text{P}^6}
+        \right)\,.
   \end{aligned}
+\end{equation}
+Note for any fixed positive value of $\tau$, the potential is minimized for $\theta = 0$.
+Thus to simplify the analysis we will set $\theta = 0$ as an initial condition, and only consider inflation in $\tau$.
+We further normalize the kinetic term by considering
+\begin{equation}
+  \tau / M_\text{P} = e^{\sqrt{2 / 3} \rho / M_\text{P}}\,,
+\end{equation}
+where $\rho$ is a new field that now has a canonical kinetic energy.
+
+The potential Eq.~(\ref{eq:KKLT:LslowUnnormalized}) has a minimum at
+\begin{equation}
+  \rho_\text{final} / M_\text{P} = \sqrt{\frac{3}{2}} \log\left(
+    - \frac{1}{\pi} \mathcal{W}_{-1}\left(\frac{3 W_0}{-2 A e^{3 / 2}}\right)
+    - \frac{3}{2 \pi}
+  \right)\,,
+\end{equation}
+which is where the inflation ends.
+To avoid eternal inflation, we add a constant to the potential so that $V\left(\rho_0\right) = 0$.
+
+Thus the potential we use for simulation takes the form
+\begin{equation} \label{eq:KKLT:Vslow}
+  V\left(\rho\right) = \tilde V\left(\rho\right) - \tilde V\left(\rho_\text{final}\right)\,,
 \end{equation}
 where
-\begin{equation} \label{eq:KKLT:VslowCoefficients}
+\begin{equation}
   \begin{aligned}
-    C_1 &= \frac{\gamma_1}{3 \left(\gamma_2 - \gamma_1\right)} \frac{B_2}{M_\text{P}^3}\,,\\
-    C_2 &= \frac{\gamma_2}{3 \left(\gamma_1 - \gamma_2\right)} \frac{B_1}{M_\text{P}^3}\,,\\
-    C_3 &= -\frac{\gamma_3}{3} \frac{\mathcal{A}_3}{M_\text{P}^3}\,,\\
-    C_{12} &= \frac
-        {\sqrt{2 / 3} \gamma_1 \gamma_2 + \left(\gamma_1 + \gamma_2\right) f / M_\text{P}}
-        {3 \left(\gamma_1 - \gamma_2\right)^2}
-      \frac{B_1 B_2}{M_\text{P}^6}\,,\\
-    C_{13} &= \frac
-        {\sqrt{2 / 3} \gamma_1 \gamma_3 + \left(\gamma_1 + \gamma_3\right) f / M_\text{P}}
-        {3 \left(\gamma_2 - \gamma_1\right)}
-      \frac{\mathcal{A}_3 B_2}{M_\text{P}^6}\,,\\
-    C_{23} &= \frac
-        {\sqrt{2 / 3} \gamma_2 \gamma_3 + \left(\gamma_2 + \gamma_3\right) f / M_\text{P}}
-        {3 \left(\gamma_1 - \gamma_2\right)}
-      \frac{\mathcal{A}_3 B_1}{M_\text{P}^6}\,,
+    \tilde V\left(\rho\right) =
+      M_\text{P}^4 \frac{\pi}{2} e^{-\sqrt{2 / 3} \rho / M_\text{P}} &\left(
+          \left(\frac{\pi}{3} + e^{-\sqrt{2 / 3} \rho / M_\text{P}}\right)
+            e^{-2 \pi e^{\sqrt{2 / 3} \rho / M_\text{P}}}
+            \frac{A^2}{M_\text{P}^6}\right.\\
+        &~~~~~~ \left.{}
+        - e^{-\sqrt{2 / 3} \rho / M_\text{P}}
+            e^{-\pi e^{\sqrt{2 / 3} \rho / M_\text{P}}}
+            \frac{A W_0}{M_\text{P}^6}
+      \right)\,.
   \end{aligned}
-\end{equation}
-and
-\begin{equation}
-  B_k = \left(\gamma_k - \gamma_3\right) \mathcal{A}_3 + \gamma_k W_0\,,
-\end{equation}
-\begin{equation}
-  \mathcal{A}_3 = e^{-\sqrt{3 / 2} \gamma_3 M_\text{P} / f} A_3\,.
 \end{equation}
 
 \begin{figure}
@@ -608,14 +584,14 @@ and
     \includegraphics[width = \textwidth]{figures/kklt_potential.pdf}
   \end{subfigure}
   \caption{\protect\input{figures/kklt.txt}
-    All panels show similar results as on Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}).
-    Note $f$ is the only continuous parameter affecting the shape of the potential, so fine-tuning it is necessary for experimentally consistent inflation.} \label{fig:kklt}
+    First four panels show similar results as on Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}).
+    The bottom panel shows the potential for $W_0 = 10^{-12} M_\text{P}^3$.} \label{fig:kklt}
 \end{figure}
 
 Simulation results for this potential are shown on Fig.~(\ref{fig:kklt}).
-We first note that due of our choice of $A_3 \gg W_0$, the terms in Eq.~(\ref{eq:KKLT:Vslow}) proportional to $W_0$ are insignificant, and $A_3^2$ becomes a multiplicative factor of the entire potential.
-As a result, the values of both $A_3$ and $W_0$ have insignificant effect on the inflation dynamics.
-We further note all points shown on Fig.~(\ref{fig:kklt}) have $0.01 \le A_k / M_\text{P}^3 \le 1$ for $k = 1, 2, 3$.
+We first note that as there is no axion decay constant $f$ in this model, the only two parameters are $N_\text{pivot}$ and $W_0$.
+Note, however, that the values of $f_e \approx f_{eH}$ we obtain from Eqs.~(\ref{eq:feFromPotential}, \ref{eq:feFromDynamicSlowRollParameters}) still satisfy Eq.~(\ref{eq:feExperimentalConstraint}).
+It is also interesting to note that inflation is guaranteed to occur in this model as long as $\rho_0$ is large enough, and for all parameter sets considered we obtained $r$ and $n_s$ consistent with experimental constraints Eq.~(\ref{data}).
 
 \section{Inflation in Large Volume Scenario (LVS) \label{sec:LVS}}
 Next we consider the Large Volume Scenario (LVS)~\cite{Balasubramanian:2005zx} where the K\"ahler potential has the form

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -325,7 +325,7 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
 In order to verify consistency with experiment and evaluate $f_e$, we use Inflation Simulator\footnote{\url{https://github.com/maxitg/InflationSimulator}}.
 For these simulations we begin by sampling a number of parameter sets as described in the caption of Fig.~(\ref{fig:supersymmetry}).
 We then use the Lagrangian $\mathcal{L} = \frac{1}{2} \dot b_-^2 - V_\text{slow}\left(b_-\right)$ and Friedmann equations described in section~4 of~\cite{Nath:2018xxe} to simulate evolution of the field and the scale factor.
-We set initial field velocity $\dot b_{-, 0} = 0$, and check that at least $N_\text{pivot} + N_\text{subhorizont}$ e-foldings are produced, where $N_\text{subhorizon} = 5$ is added to ensure velocity converges to its quasi-stationary value before horizon exit.
+We set initial field velocity $\dot b_{-, \text{init}} = 0$, and check that at least $N_\text{pivot} + N_\text{subhorizont}$ e-foldings are produced, where $N_\text{subhorizon} = 5$ is added to ensure velocity converges to its quasi-stationary value before horizon exit.
 Finally, if we have sufficient e-foldings, we compute the tensor-to-scalar ratio $r$, and the scalar spectral index $n_s$ at horizon exit (i.e., $N_\text{pivot}$ e-foldings before the end of inflation) using Eqs.~(\ref{eq:slowRollParametersDynamic}, \ref{eq:slowRollParametersDynamicFromStatic}, \ref{eq:observablesSlowRoll}), and check if they are consistent with experimental constraints~\cite{Ade:2015lrj}.
 If so, we evaluate $f_e$ and $f_{eH}$ at horizon exit using Eqs.~(\ref{eq:feFromPotential}, \ref{eq:feFromDynamicSlowRollParameters}).
 The results of this process can be seen on Fig.~(\ref{fig:supersymmetry}).
@@ -536,19 +536,31 @@ We further normalize the kinetic term by considering
 \end{equation}
 where $\rho$ is a new field that now has a canonical kinetic energy.
 
-The potential Eq.~(\ref{eq:KKLT:LslowUnnormalized}) has a minimum at
+The potential Eq.~(\ref{eq:KKLT:LslowUnnormalized}) has a minimum at which the inflation ends at
 \begin{equation}
-  \rho_\text{final} / M_\text{P} = \sqrt{\frac{3}{2}} \log\left(
+  \rho_0 / M_\text{P} = \sqrt{\frac{3}{2}} \log\left(
     - \frac{1}{\pi} \mathcal{W}_{-1}\left(\frac{3 W_0}{-2 A e^{3 / 2}}\right)
     - \frac{3}{2 \pi}
   \right)\,,
 \end{equation}
-which is where the inflation ends.
-To avoid eternal inflation, we add a constant to the potential so that $V\left(\rho_0\right) = 0$.
+where $\mathcal{W}_{-1}\left(z\right)$ is the lower branch of product logarithm, which is a solution to $\mathcal{W}_{-1} e^{\mathcal{W}_{-1}} = z$ such that $\mathcal{W}_{-1} \le -1$.
+To avoid negative vacuum density at the end of inflation, we add a fine-tuned constant to the potential so that $V\left(\rho_0\right) = 0$.
+The constant might be caused by vacuum density contributions from the fields other than ones considered in this model.
 
-Thus the potential we use for simulation takes the form
+Note that although we consider inflation in $\rho$, it is still interesting to see the value of the axion decay constant for the axion field $\theta$ at the end of inflation.
+For that, we normalize its kinetic energy by considering the field $a$ such that
+\begin{equation}
+  a = \sqrt\frac{3}{2} \frac{M_\text{P}}{\tau_0} \theta = \sqrt\frac{3}{2} e^{- \sqrt{2 / 3} \rho_0 / M_\text{P}} \theta\,,
+\end{equation}
+and defining the axion decay constant as before we get
+\begin{equation}
+  f = \frac{1}{\pi} \sqrt\frac{3}{2} e^{- \sqrt{2 / 3} \rho_0 / M_\text{P}}\,,
+\end{equation}
+which for $A = M_\text{P}^3$ and $\log_{10}{W_0 / M_\text{P}^3} \in \left(-14, -10\right)$ takes the values $f \in \left(0.10, 0.15\right) M_\text{P}$.
+
+The potential we use for simulation takes the form
 \begin{equation} \label{eq:KKLT:Vslow}
-  V\left(\rho\right) = \tilde V\left(\rho\right) - \tilde V\left(\rho_\text{final}\right)\,,
+  V\left(\rho\right) = \tilde V\left(\rho\right) - \tilde V\left(\rho_0\right)\,,
 \end{equation}
 where
 \begin{equation}
@@ -591,7 +603,7 @@ where
 Simulation results for this potential are shown on Fig.~(\ref{fig:kklt}).
 We first note that as there is no axion decay constant $f$ in this model, the only two parameters are $N_\text{pivot}$ and $W_0$.
 Note, however, that the values of $f_e \approx f_{eH}$ we obtain from Eqs.~(\ref{eq:feFromPotential}, \ref{eq:feFromDynamicSlowRollParameters}) still satisfy Eq.~(\ref{eq:feExperimentalConstraint}).
-It is also interesting to note that inflation is guaranteed to occur in this model as long as $\rho_0$ is large enough, and for all parameter sets considered we obtained $r$ and $n_s$ consistent with experimental constraints Eq.~(\ref{data}).
+It is also interesting to note that inflation is guaranteed to occur in this model as long as $\rho_\text{init}$ is large enough, and for all parameter sets considered we obtained $r$ and $n_s$ consistent with experimental constraints Eq.~(\ref{data}).
 
 \section{Inflation in Large Volume Scenario (LVS) \label{sec:LVS}}
 Next we consider the Large Volume Scenario (LVS)~\cite{Balasubramanian:2005zx} where the K\"ahler potential has the form

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -492,71 +492,125 @@ We wish to discuss the coherent enhancement of the decay constant in KKLT~\cite{
 The scalar potential of the theory is as given by Eq.~(\ref{eq:supergravity:potential}) and Eq.~(\ref{eq:supergravity:DW}).
 In the KKLT analysis we consider a K\"ahler potential with a single modulus $T$ so that
 \begin{equation} \label{eq:KKLT:kahler}
-  K = -3 \log\left(T + \bar T\right)\,,
+  K = -3 M_\text{P}^2 \log\left(\frac{T + \bar T}{M_\text{P}}\right)\,,
 \end{equation}
 where we may decompose $T$ so that $T = \tau + i \theta$.
 We assume the superpotential $W$ where the modulus dependence arises only in the non-perturbative terms and we take $W$ to have the form
 \begin{equation} \label{eq:KKLT:W}
-  W = W_0 + \sum_i A_i e^{-q_i T}\,,
+  W = W_0 + \sum_{n = 1}^q A_n e^{-\gamma_n T / M_\text{P}}\,,
 \end{equation}
-where the modulus $T$ appears only in the exponent and where $A_i$ and $q_i$ are assumed real.
+where the modulus $T$ appears only in the exponent and where $A_n$ and $\gamma_n$ are assumed real.
 For the K\"ahler potential of Eq.~(\ref{eq:KKLT:kahler}) the scalar potential Eq.~(\ref{eq:supergravity:potential}) takes the form
 \begin{equation}
   V = e^{K / M_\text{P}^2} K^{T \bar T} \left[
     \partial_T W \partial_{\bar T} \bar W +
-    \frac{1}{M_\text{P}^2}\left(\partial_T K W \partial_{\bar T} \bar W + \partial_{\bar T} K \bar W \partial_T W\right)
+    \frac{1}{M_\text{P}^2}\left(
+        \partial_T K W \partial_{\bar T} \bar W
+      + \partial_{\bar T} K \bar W \partial_T W\right)
   \right]\,.
 \end{equation}
 An explicit computation of $V$ gives
 \begin{equation} \label{eq:KKLT:VslowUnstabilized}
   \begin{aligned}
-    V = \frac{1}{6 \tau} &\left[
-        \sum_{i, j} A_i A_j q_i q_j e^{-\left(q_i + q_j\right)\tau}
-        \cos\left(\left(q_i - q_j\right) \theta\right)\right.\\
-    &{}\left. + \frac{3}{\tau} W_0 \sum_i A_i q_i e^{-q_i \tau} \cos\left(q_i \theta\right)
-      + \frac{3}{\tau} \sum_{i, j} A_i A_j q_j e^{-\left(q_i + q_j\right) \tau}
-        \cos\left(\left(q_i - q_j\right)\theta\right)
+    V = \frac{1}{6 \tau M_\text{P}} &\left[
+        \sum_{n = 1}^q \sum_{m = 1}^q A_n A_m \gamma_n
+          \left(\gamma_m + \frac{3 M_\text{P}}{\tau}\right)
+          e^{-\left(\gamma_n + \gamma_m\right)\tau / M_\text{P}}
+          \cos\left(\left(\gamma_n - \gamma_m\right) \frac{\theta}{M_\text{P}}\right)\right.\\
+        &\left.{}
+      + \frac{3 M_\text{P}}{\tau} W_0
+          \sum_{n = 1}^q A_n \gamma_n e^{-\gamma_n \tau / M_\text{P}}
+          \cos\left(\gamma_n \frac{\theta}{M_\text{P}}\right)
     \right]\,.
   \end{aligned}
 \end{equation}
 To stabilize the modulus $\tau$ we use the condition~\cite{Nath:1983aw}
 \begin{equation} \label{eq:KKLT:stabilization}
-  D_{,T} W = 0\,,
+  D_T W = 0\,,
 \end{equation}
 which gives the constraint
 \begin{equation} \label{eq:KKLT:W0}
-  W_0 = -\sum_i A_i e^{-q_i \tau_0} \left(1 + \frac{2}{3} q_i \tau_0\right)\,,
+  W_0 = -\sum_{n = 1}^q A_n e^{-\gamma_n \tau_0 / M_\text{P}}
+    \left(1 + \frac{2}{3} \gamma_n \frac{\tau_0}{M_\text{P}}\right)\,,
 \end{equation}
 where $\left<T\right> = \tau_0, \left<\theta\right> = 0$.
-Next wer expand $T$ around the critical point, i.e., $T = \tau_0 + \tau' + \theta$.
+Next we expand $T$ around the critical point, i.e., $T = \tau_0 + \tau' + \theta$.
 However, the kinetic energy using $\tau$ and $\theta$ is not canonically normalized and we define the normalized fields $\rho, a$ so that
 \begin{equation} \label{eq:KKLT:rho.a}
-  \rho \equiv \frac{\sqrt 3}{\sqrt{2} \tau_0} \tau',
-  ~~~ a \equiv \frac{\sqrt 3}{\sqrt{2} \tau_0} \theta\,,
+  \rho \equiv \frac{\sqrt{3} M_\text{P}}{\sqrt{2} \tau_0} \tau',
+  ~~~ a \equiv \frac{\sqrt{3} M_\text{P}}{\sqrt{2} \tau_0} \theta\,,
 \end{equation}
 for which the kinetic energy takes the canonical form, i.e, $L_\text{kin} = -\frac{1}{2} \left[\partial_\mu \rho \partial^\mu \rho + \partial_\mu a \partial^\mu a\right]$.
-Using the canonically normalized fields we can define the axion decay constant so that $f = \frac{\sqrt 3}{\sqrt{2} \tau_0}$.
-The potential for the normalized axion field expanded around the stabilized moduli gives
+Using the canonically normalized fields we can define the axion decay constant so that $f = \frac{\sqrt{3} M_\text{P}^2}{\sqrt{2} \tau_0}$.
+
+We further require that the vacuum energy vanishes at the minimum of the potential, and this can be achieved by setting $W = 0$ along with the stability condition Eq.~(\ref{eq:KKLT:stabilization}).
+These conditions lead to the constraint
+\begin{equation} \label{eq:KKLT:zeroVacuumConstraint}
+  \sum_{n = 1}^q A_n \gamma_n e^{-\gamma_n \tau_0} = 0\,,
+\end{equation}
+which we solve for $A_1$.
+The imposition of Eqs.~(\ref{eq:KKLT:stabilization}, \ref{eq:KKLT:zeroVacuumConstraint}) would lead to moduli stabilization and vanishing of the vacuum energy at the end of inflation.
+
+For our simulation, we take $q = 3$, in which case we get the following potential
 \begin{equation} \label{eq:KKLT:Vslow}
-  V = C^K
-    + \sum_i C^K_i \cos\left(\frac{q_i a}{f}\right)
-    + \sum_{ij} C^K_{ij} \cos\left(\frac{\left(q_i - q_j\right) a}{f}\right)\,,
+  V = M_\text{P}^4 \left(
+      \sum_{n = 1}^3 C_n \left(1 - \cos\left(\frac{\gamma_n a}{f}\right)\right)
+    + \sum_{n = 1}^3 \sum_{m = 1}^3 C_{n m}
+        \left(1 - \cos\left(\frac{\left(\gamma_n - \gamma_m\right) a}{f}\right)\right)\right)\,,
 \end{equation}
 where
 \begin{equation} \label{eq:KKLT:VslowCoefficients}
   \begin{aligned}
-    C^K &= \frac{1}{6 \tau_0} \sum_i A^2_i q^2_i e^{-2 q_i \tau_0}\,,\\
-    C^K_i &= \frac{3}{\tau_0} W_0 \sum_i A_i q_i e^{-q_i \tau_0}\,,\\
-    C^K_{ij} &= 2 \sum_{i > j} A_i A_j q_i q_j e^{-\left(q_i + q_j\right) \tau_0}
-      + \frac{3}{\tau_0} \sum_{i, j} A_i A_j q_j e^{-\left(q_i + q_j\right) \tau_0}\,.
+    C_1 &= \frac{1}{3 \gamma_1} \frac{f^2}{M_\text{P}^2} \left(
+        \left(-\gamma_1 \gamma_2 + \gamma_2^2\right)
+          e^{-\sqrt{6} \gamma_2 M_\text{P} / f} \frac{A_2^2}{M_\text{P}^6}
+      + \left(-\gamma_1 \gamma_3 + \gamma_3^2\right)
+          e^{-\sqrt{6} \gamma_3 M_\text{P} / f} \frac{A_3^2}{M_\text{P}^6}\right.\\
+      &~~~~~~ \left.{}
+      + \left(-\gamma_1 \gamma_2 - \gamma_1 \gamma_3 + 2 \gamma_2 \gamma_3\right)
+          e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
+          \frac{A_2 A_3}{M_\text{P}^6}
+    \right)\,,\\
+    C_2 &= \frac{\gamma_2}{3 \gamma_1} \frac{f^2}{M_\text{P}^2} \left(
+        \left(\gamma_1 - \gamma_2\right)
+          e^{-\sqrt{6} \gamma_2 M_\text{P} / f} \frac{A_2^2}{M_\text{P}^6}
+      + \left(\gamma_1 - \gamma_3\right)
+        e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
+        \frac{A_2 A_3}{M_\text{P}^6}
+    \right)\,,\\
+    C_3 &= \frac{\gamma_3}{3 \gamma_1} \frac{f^2}{M_\text{P}^2} \left(
+        \left(\gamma_1 - \gamma_3\right)
+          e^{-\sqrt{6} \gamma_3 M_\text{P} / f} \frac{A_3^2}{M_\text{P}^6}
+      + \left(\gamma_1 - \gamma_2\right)
+          e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
+          \frac{A_2 A_3}{M_\text{P}^6}
+    \right)\,,\\
+    C_{12} &= \left(
+          \frac{\sqrt{6} \gamma_2}{9} + \frac{\gamma_1 + \gamma_2}{3 \gamma_1} \frac{f}{M_\text{P}}
+      \right)
+      \frac{f}{M_\text{P}}
+      \left(
+          \gamma_2 e^{-\sqrt{6} \gamma_2 M_\text{P} / f} \frac{A_2^2}{M_\text{P}^6}
+        + \gamma_3 e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
+            \frac{A_2 A_3}{M_\text{P}^6}
+      \right)\,,\\
+    C_{13} &= \left(
+          \frac{\sqrt{6} \gamma_3}{9} + \frac{\gamma_1 + \gamma_3}{3 \gamma_1} \frac{f}{M_\text{P}}
+      \right)
+      \frac{f}{M_\text{P}}
+      \left(
+          \gamma_3 e^{-\sqrt{6} \gamma_3 M_\text{P} / f} \frac{A_3^2}{M_\text{P}^6}
+        + \gamma_2 e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
+            \frac{A_2 A_3}{M_\text{P}^6}
+      \right)\,,\\
+    C_{23} &= -\left(
+          \frac{\sqrt{6} \gamma_2 \gamma_3}{9} + \frac{\gamma_2 + \gamma_3}{3} \frac{f}{M_\text{P}}
+      \right)
+      \frac{f}{M_\text{P}}
+      e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
+      \frac{A_2 A_3}{M_\text{P}^6}\,.
   \end{aligned}
 \end{equation}
-We require that the vacuum energy vanish at the minimum of the potential, and this can be achieved by setting $W = 0$ along with the stability condition $D_i W = 0$.
-These conditions lead to the constraint
-\begin{equation} \label{eq:KKLT:zeroVacuumConstraint}
-  \sum_i A_i q_i e^{-q_i \tau_0} = 0\,.
-\end{equation}
-The imposition of Eqs.~(\ref{eq:KKLT:stabilization}, \ref{eq:KKLT:zeroVacuumConstraint}) would lead to moduli stabilization and vanishing of the vacuum energy at the end of inflation.
 
 % TODO(maxitg): Simulation part needs to be added here.
 

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -546,70 +546,48 @@ Using the canonically normalized fields we can define the axion decay constant s
 We further require that the vacuum energy vanishes at the minimum of the potential, and this can be achieved by setting $W = 0$ along with the stability condition Eq.~(\ref{eq:KKLT:stabilization}).
 These conditions lead to the constraint
 \begin{equation} \label{eq:KKLT:zeroVacuumConstraint}
-  \sum_{n = 1}^q A_n \gamma_n e^{-\gamma_n \tau_0} = 0\,,
+  \sum_{n = 1}^q A_n \gamma_n e^{-\gamma_n \tau_0 / M_\text{P}} = 0\,.
 \end{equation}
-which we solve for $A_1$.
 The imposition of Eqs.~(\ref{eq:KKLT:stabilization}, \ref{eq:KKLT:zeroVacuumConstraint}) would lead to moduli stabilization and vanishing of the vacuum energy at the end of inflation.
+For our simulation we solve these constraints for $A_1$ and $A_2$, and we vary $W_0$ and $f$ instead.
 
-For our simulation, we take $q = 3$, in which case we get the following potential
+Specifically, we take $q = 3$, in which case we get the following potential
 \begin{equation} \label{eq:KKLT:Vslow}
-  V = M_\text{P}^4 \left(
-      \sum_{n = 1}^3 C_n \left(1 - \cos\left(\frac{\gamma_n a}{f}\right)\right)
-    + \sum_{n = 1}^3 \sum_{m = 1}^3 C_{n m}
-        \left(1 - \cos\left(\frac{\left(\gamma_n - \gamma_m\right) a}{f}\right)\right)\right)\,,
+  \begin{aligned}
+    V = M_\text{P}^4 &\left(
+        \frac{f^2}{M_\text{P}^2} \frac{W_0}{M_\text{P}^3} \sum_{n = 1}^3 C_n
+          \left(1 - \cos\left(\frac{\gamma_n a}{f}\right)\right)\right.\\
+      &~~~~~~{} \left.
+      + \frac{f}{M_\text{P}} \sum_{n = 1}^3 \sum_{m = n + 1}^3 C_{n m}
+          \left(1 - \cos\left(\frac{\left(\gamma_n - \gamma_m\right) a}{f}\right)\right)\right)\,,
+  \end{aligned}
 \end{equation}
 where
 \begin{equation} \label{eq:KKLT:VslowCoefficients}
   \begin{aligned}
-    C_1 &= \frac{1}{3 \gamma_1} \frac{f^2}{M_\text{P}^2} \left(
-        \left(-\gamma_1 \gamma_2 + \gamma_2^2\right)
-          e^{-\sqrt{6} \gamma_2 M_\text{P} / f} \frac{A_2^2}{M_\text{P}^6}
-      + \left(-\gamma_1 \gamma_3 + \gamma_3^2\right)
-          e^{-\sqrt{6} \gamma_3 M_\text{P} / f} \frac{A_3^2}{M_\text{P}^6}\right.\\
-      &~~~~~~ \left.{}
-      + \left(-\gamma_1 \gamma_2 - \gamma_1 \gamma_3 + 2 \gamma_2 \gamma_3\right)
-          e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
-          \frac{A_2 A_3}{M_\text{P}^6}
-    \right)\,,\\
-    C_2 &= \frac{\gamma_2}{3 \gamma_1} \frac{f^2}{M_\text{P}^2} \left(
-        \left(\gamma_1 - \gamma_2\right)
-          e^{-\sqrt{6} \gamma_2 M_\text{P} / f} \frac{A_2^2}{M_\text{P}^6}
-      + \left(\gamma_1 - \gamma_3\right)
-        e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
-        \frac{A_2 A_3}{M_\text{P}^6}
-    \right)\,,\\
-    C_3 &= \frac{\gamma_3}{3 \gamma_1} \frac{f^2}{M_\text{P}^2} \left(
-        \left(\gamma_1 - \gamma_3\right)
-          e^{-\sqrt{6} \gamma_3 M_\text{P} / f} \frac{A_3^2}{M_\text{P}^6}
-      + \left(\gamma_1 - \gamma_2\right)
-          e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
-          \frac{A_2 A_3}{M_\text{P}^6}
-    \right)\,,\\
-    C_{12} &= \left(
-          \frac{\sqrt{6} \gamma_2}{9} + \frac{\gamma_1 + \gamma_2}{3 \gamma_1} \frac{f}{M_\text{P}}
-      \right)
-      \frac{f}{M_\text{P}}
-      \left(
-          \gamma_2 e^{-\sqrt{6} \gamma_2 M_\text{P} / f} \frac{A_2^2}{M_\text{P}^6}
-        + \gamma_3 e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
-            \frac{A_2 A_3}{M_\text{P}^6}
-      \right)\,,\\
-    C_{13} &= \left(
-          \frac{\sqrt{6} \gamma_3}{9} + \frac{\gamma_1 + \gamma_3}{3 \gamma_1} \frac{f}{M_\text{P}}
-      \right)
-      \frac{f}{M_\text{P}}
-      \left(
-          \gamma_3 e^{-\sqrt{6} \gamma_3 M_\text{P} / f} \frac{A_3^2}{M_\text{P}^6}
-        + \gamma_2 e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
-            \frac{A_2 A_3}{M_\text{P}^6}
-      \right)\,,\\
-    C_{23} &= -\left(
-          \frac{\sqrt{6} \gamma_2 \gamma_3}{9} + \frac{\gamma_2 + \gamma_3}{3} \frac{f}{M_\text{P}}
-      \right)
-      \frac{f}{M_\text{P}}
-      e^{-\sqrt{3 / 2} \left(\gamma_2 + \gamma_3\right) M_\text{P} / f}
-      \frac{A_2 A_3}{M_\text{P}^6}\,.
+    C_1 &= \frac{\gamma_1}{3 \left(\gamma_2 - \gamma_1\right)} \frac{B_2}{M_\text{P}^3}\,,\\
+    C_2 &= \frac{\gamma_2}{3 \left(\gamma_1 - \gamma_2\right)} \frac{B_1}{M_\text{P}^3}\,,\\
+    C_3 &= -\frac{\gamma_3}{3} \frac{\mathcal{A}_3}{M_\text{P}^3}\,,\\
+    C_{12} &= \frac
+        {\sqrt{2 / 3} \gamma_1 \gamma_2 + \left(\gamma_1 + \gamma_2\right) f / M_\text{P}}
+        {3 \left(\gamma_1 - \gamma_2\right)^2}
+      \frac{B_1 B_2}{M_\text{P}^6}\,,\\
+    C_{13} &= \frac
+        {\sqrt{2 / 3} \gamma_1 \gamma_3 + \left(\gamma_1 + \gamma_3\right) f / M_\text{P}}
+        {3 \left(\gamma_2 - \gamma_1\right)}
+      \frac{\mathcal{A}_3 B_2}{M_\text{P}^6}\,,\\
+    C_{23} &= \frac
+        {\sqrt{2 / 3} \gamma_2 \gamma_3 + \left(\gamma_2 + \gamma_3\right) f / M_\text{P}}
+        {3 \left(\gamma_1 - \gamma_2\right)}
+      \frac{\mathcal{A}_3 B_1}{M_\text{P}^6}\,,
   \end{aligned}
+\end{equation}
+and
+\begin{equation}
+  B_k = \left(\gamma_k - \gamma_3\right) \mathcal{A}_3 + \gamma_k W_0\,,
+\end{equation}
+\begin{equation}
+  \mathcal{A}_3 = e^{-\sqrt{3 / 2} \gamma_3 M_\text{P} / f} A_3\,.
 \end{equation}
 
 % TODO(maxitg): Simulation part needs to be added here.

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -301,7 +301,7 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
     \includegraphics[width = \textwidth]{figures/supersymmetry_f_r.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/supersymmetry_exitField_fStatic_ratio.pdf}
+    \includegraphics[width = \textwidth]{figures/supersymmetry_fieldRange_fStatic_ratio.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supersymmetry_f_fStatic.pdf}
@@ -472,7 +472,7 @@ Note, the Lyth bound~\cite{Lyth:1996im} for slow-roll inflation is satisfied in 
     \includegraphics[width = \textwidth]{figures/supergravity_f_r.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/supergravity_exitField_fStatic_ratio.pdf}
+    \includegraphics[width = \textwidth]{figures/supergravity_fieldRange_fStatic_ratio.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supergravity_f_fStatic.pdf}
@@ -593,19 +593,19 @@ and
 \begin{figure}
   \centering
   \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/kklt_f_r.pdf}
+    \includegraphics[width = \textwidth]{figures/kklt_pivotEfoldings_r.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/kklt_exitField_fStatic_ratio.pdf}
+    \includegraphics[width = \textwidth]{figures/kklt_fieldRange_fStatic_ratio.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/kklt_f_fStatic.pdf}
+    \includegraphics[width = \textwidth]{figures/kklt_pivotEfoldings_fStatic.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/kklt_fStatic_fDynamic.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/kklt_potentialRange.pdf}
+    \includegraphics[width = \textwidth]{figures/kklt_potential.pdf}
   \end{subfigure}
   \caption{\protect\input{figures/kklt.txt}
     All panels show similar results as on Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}).

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -325,8 +325,8 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
 In order to verify consistency with experiment and evaluate $f_e$, we use Inflation Simulator\footnote{\url{https://github.com/maxitg/InflationSimulator}}.
 For these simulations we begin by sampling a number of parameter sets as described in the caption of Fig.~(\ref{fig:supersymmetry}).
 We then use the Lagrangian $\mathcal{L} = \frac{1}{2} \dot b_-^2 - V_\text{slow}\left(b_-\right)$ and Friedmann equations described in section~4 of~\cite{Nath:2018xxe} to simulate evolution of the field and the scale factor.
-We set initial field velocity $\dot b_{-, 0} = 0$, which does not affect the results, as velocity typically converges to its quasi-stationary value before horizon exit.
-Finally, if at least $N_\text{pivot}$ e-foldings are produced, we compute the tensor-to-scalar ratio $r$, and the scalar spectral index $n_s$ at horizon exit (i.e., $N_\text{pivot}$ e-foldings before the end of inflation) using Eqs.~(\ref{eq:slowRollParametersDynamic}, \ref{eq:slowRollParametersDynamicFromStatic}, \ref{eq:observablesSlowRoll}), and check if they are consistent with experimental constraints~\cite{Ade:2015lrj}.
+We set initial field velocity $\dot b_{-, 0} = 0$, and check that at least $N_\text{pivot} + N_\text{subhorizont}$ e-foldings are produced, where $N_\text{subhorizon} = 5$ is added to ensure velocity converges to its quasi-stationary value before horizon exit.
+Finally, if we have sufficient e-foldings, we compute the tensor-to-scalar ratio $r$, and the scalar spectral index $n_s$ at horizon exit (i.e., $N_\text{pivot}$ e-foldings before the end of inflation) using Eqs.~(\ref{eq:slowRollParametersDynamic}, \ref{eq:slowRollParametersDynamicFromStatic}, \ref{eq:observablesSlowRoll}), and check if they are consistent with experimental constraints~\cite{Ade:2015lrj}.
 If so, we evaluate $f_e$ and $f_{eH}$ at horizon exit using Eqs.~(\ref{eq:feFromPotential}, \ref{eq:feFromDynamicSlowRollParameters}).
 The results of this process can be seen on Fig.~(\ref{fig:supersymmetry}).
 
@@ -590,7 +590,32 @@ and
   \mathcal{A}_3 = e^{-\sqrt{3 / 2} \gamma_3 M_\text{P} / f} A_3\,.
 \end{equation}
 
-% TODO(maxitg): Simulation part needs to be added here.
+\begin{figure}
+  \centering
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/kklt_f_r.pdf}
+  \end{subfigure}
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/kklt_exitField_fStatic_ratio.pdf}
+  \end{subfigure}
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/kklt_f_fStatic.pdf}
+  \end{subfigure}
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/kklt_fStatic_fDynamic.pdf}
+  \end{subfigure}
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/kklt_potentialRange.pdf}
+  \end{subfigure}
+  \caption{\protect\input{figures/kklt.txt}
+    All panels show similar results as on Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}).
+    Note $f$ is the only continuous parameter affecting the shape of the potential, so fine-tuning it is necessary for experimentally consistent inflation.} \label{fig:kklt}
+\end{figure}
+
+Simulation results for this potential are shown on Fig.~(\ref{fig:kklt}).
+We first note that due of our choice of $A_3 \gg W_0$, the terms in Eq.~(\ref{eq:KKLT:Vslow}) proportional to $W_0$ are insignificant, and $A_3^2$ becomes a multiplicative factor of the entire potential.
+As a result, the values of both $A_3$ and $W_0$ have insignificant effect on the inflation dynamics.
+We further note all points shown on Fig.~(\ref{fig:kklt}) have $0.01 \le A_k / M_\text{P}^3 \le 1$ for $k = 1, 2, 3$.
 
 \section{Inflation in Large Volume Scenario (LVS) \label{sec:LVS}}
 Next we consider the Large Volume Scenario (LVS)~\cite{Balasubramanian:2005zx} where the K\"ahler potential has the form

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -339,14 +339,6 @@ supersymmetrySpecs = <|
 		"$N_\\text{pivot} \\sim <*distribution[\"pivotEfoldings\"]*>$."|>;
 
 
-If[Head[supersymmetrySpecs["parameterDistributions"]["G5"]] =!= UniformDistribution,
-	Print[
-		"G5 in supersymmetry is not uniformly distributed, however the ",
-		"figure caption says that it is. Compilation is aborted."];
-	Quit[];
-];
-
-
 (* ::Section:: *)
 (*Supergravity*)
 
@@ -430,12 +422,20 @@ kkltSpecs = <|
 	"fieldLabel" -> italicLabel["\[Rho]"],
 	"caption" -> "Simulation results for KKLT " <>
 		"Eq.~(\\ref{eq:KKLT:Vslow}). " <>
-		"Simulation consisted of a total of `totalPoints` points, out of which " <>
-		"`points` shown are consistent with experimental data on $r$ and $n_s$. " <>
-		"Here $W_0 = <*distribution[\"W0\"]*> M_\\text{P}^3$, " <>
-		"$f / M_\\text{P} \\sim <*distribution[\"f\", {2, 1}]*>$, " <>
-		"$a / f \\sim <*distribution[\"fieldInitialOverF\"]*>$, " <>
+		"Simulation consisted of a total of `totalPoints` points, all of which " <>
+		"consistent with experimental data on $r$ and $n_s$. " <>
+		"Here $A = M_\\text{P}^3$, " <>
+		"$\\log_{10}\\left(W_0 / M_\\text{P}^3\\right) = " <>
+			"<*distribution[\"logW0\"]*>$, " <>
+		"$\\rho_0 = 3.32 M_\\text{P}$, " <>
 		"$N_\\text{pivot} \\sim <*distribution[\"pivotEfoldings\"]*>$."|>;
+
+
+If[kkltSpecs["parameterDistributions"]["fieldInitialOverF"] =!=
+		UniformDistribution[{3.32, 3.32}],
+	Print["Initial field in KKLT is hardcoded to the wrong value."];
+	Quit[1];
+];
 
 
 (* ::Section:: *)

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -335,7 +335,7 @@ supersymmetrySpecs = <|
 		"We set $B = 1$, as it only affects the time scale of inflation, but not " <>
 		"the values of $n_s$, $r$, and $f_e$. " <>
 		"Finally, $f / M_\\text{P} \\sim <*distribution[\"f\"]*>$, " <>
-		"$b_{-, 0} / f \\sim <*distribution[\"fieldInitialOverF\"]*>$, " <>
+		"$b_{-, \\text{init}} / f \\sim <*distribution[\"fieldInitialOverF\"]*>$, " <>
 		"$N_\\text{pivot} \\sim <*distribution[\"pivotEfoldings\"]*>$."|>;
 
 
@@ -382,7 +382,7 @@ supergravitySpecs = <|
 		"$A_2 \\sim <*distribution[\"A2\", {4, 3}]*>$, " <>
 		"$A_3 \\sim <*distribution[\"A3\", {5, 4}]*>$, " <>
 		"$f / M_\\text{P} \\sim <*distribution[\"f\"]*>$, " <>
-		"$b_{-, 0} / f \\sim <*distribution[\"fieldInitialOverF\"]*>$, " <>
+		"$b_{-, \\text{init}} / f \\sim <*distribution[\"fieldInitialOverF\"]*>$, " <>
 		"$N_\\text{pivot} \\sim <*distribution[\"pivotEfoldings\"]*>$."|>;
 
 
@@ -427,7 +427,7 @@ kkltSpecs = <|
 		"Here $A = M_\\text{P}^3$, " <>
 		"$\\log_{10}\\left(W_0 / M_\\text{P}^3\\right) = " <>
 			"<*distribution[\"logW0\"]*>$, " <>
-		"$\\rho_0 = 3.32 M_\\text{P}$, " <>
+		"$\\rho_\\text{init} = 3.32 M_\\text{P}$, " <>
 		"$N_\\text{pivot} \\sim <*distribution[\"pivotEfoldings\"]*>$."|>;
 
 

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -51,7 +51,7 @@ generateInputs[parameterDistributions_, seed_, n_] :=
 minSubhorizonEfoldings = 5;
 
 
-simulate[lagrangian_, inputs_] := Module[{hash, filename, results, counter},
+simulate[lagrangian_, inputs_, options_] := Module[{hash, filename, results, counter},
 	hash = Hash[{DownValues[simulate], lagrangian, inputs}];
 	filename = FileNameJoin[{cacheDirectory, IntegerString[hash, 16] <> ".wxf"}];
 	If[FileExistsQ[filename],
@@ -67,35 +67,42 @@ simulate[lagrangian_, inputs_] := Module[{hash, filename, results, counter},
 					lagrangian[#][bm[t], t],
 					{bm[t], #["f"] #["fieldInitialOverF"], 0},
 					t,
-					#["pivotEfoldings"]] &&
+					#["pivotEfoldings"],
+					options[#]] &&
 				InflationEfoldingsCount[
 					lagrangian[#][bm[t], t],
 					{bm[t], #["f"] #["fieldInitialOverF"], 0},
-					t] >= #["pivotEfoldings"] + minSubhorizonEfoldings,
+					t,
+					options[#]] >=
+							#["pivotEfoldings"] + minSubhorizonEfoldings,
 				Join[
 					#,
 					Association @ Thread[
-						{"fDynamic", "fStatic", "r", "exitField"} -> InflationValue[
-							lagrangian[#][bm[t], t],
-							{bm[t], #["f"] #["fieldInitialOverF"], 0},
-							t,
-							#["pivotEfoldings"],
-							{InflationProperty[
-								"EffectiveAxionDecayConstant",
-								"HorizonExit",
-								Method -> "FromHubbleParameter"],
-							 InflationProperty[
-								"EffectiveAxionDecayConstant",
-								"HorizonExit",
-								Method -> "FromPotential"],
-							 InflationProperty[
-								"TensorToScalarRatio",
-								"HorizonExit",
-								Method -> "FromHubbleParameter"],
-							 InflationProperty[
-								"Field",
-								"HorizonExit"]}]]
-				],
+						{"fDynamic", "fStatic", "r", "exitField", "endField"} ->
+							InflationValue[
+								lagrangian[#][bm[t], t],
+								{bm[t], #["f"] #["fieldInitialOverF"], 0},
+								t,
+								#["pivotEfoldings"],
+								{InflationProperty[
+									"EffectiveAxionDecayConstant",
+									"HorizonExit",
+									Method -> "FromHubbleParameter"],
+								 InflationProperty[
+									"EffectiveAxionDecayConstant",
+									"HorizonExit",
+									Method -> "FromPotential"],
+								 InflationProperty[
+									"TensorToScalarRatio",
+									"HorizonExit",
+									Method -> "FromHubbleParameter"],
+								 InflationProperty[
+									"Field",
+									"HorizonExit"],
+								 InflationProperty[
+									"Field",
+									"End"]},
+								options[#]]]],
 				Nothing];
 				c = ++counter;
 				If[Quotient[100 c, Length[inputs]] >
@@ -133,8 +140,10 @@ $label["fStaticUnits"] = subscriptLabel[italicLabel["f"], italicLabel["e"]];
 $label["fStatic"] = ratioLabel[$label["fStaticUnits"], planckMassLabel];
 $label["fDynamic"] =
 	ratioLabel[subscriptLabel[italicLabel["f"], italicLabel["eH"]], planckMassLabel];
-$label["exitFieldUnits"] = subscriptLabel[italicLabel["\[CapitalDelta]b"], plainLabel["-"]];
-$label["exitField"] = ratioLabel[$label["exitFieldUnits"], planckMassLabel];
+$label["fieldRange", field_] := rowLabel[{italicLabel["\[CapitalDelta]"], field}];
+$label["fieldRangeUnitless", field_] :=
+	ratioLabel[$label["fieldRange", field], planckMassLabel];
+$label["pivotEfoldings"] = subscriptLabel[italicLabel["N"], plainLabel["pivot"]];
 
 
 figureName[name_String] := name <> ".pdf"
@@ -142,41 +151,53 @@ figureName[{f_, p1_String, p2_String, args___}] := p1 <> "_" <> p2 <> ".pdf"
 figureName[{name_String, args___}] := name <> ".pdf"
 
 
-makeFigure[model_, name_, lagrangian_, output_, OptionsPattern[]] :=
+makeFigure[specs_, name_, output_, OptionsPattern[]] :=
 	Export[
 		FileNameJoin[{
 			figuresDirectory,
-			model <> "_" <> figureName[name]}],
+			specs["name"] <> "_" <> figureName[name]}],
 		Show[
-			plot[name, lagrangian, output],
+			plot[name, specs, output],
 			ImageSize -> OptionValue["imageSize"],
 			LabelStyle -> Directive[FontFamily -> OptionValue["fontFamily"]]]]
 
 
-plot[{"potentialRange", min_, max_, step_}, lagrangian_, output_] := ListPlot[
+plot[{"potentialRange", min_, max_, step_}, specs_, output_] := ListPlot[
 	ParallelTable[{bf, #[
 		Evaluate[With[{f = #[["f"]]},
-			lagrangian[#][f bf, t] / lagrangian[#][f \[Pi] Sqrt[2], t]] & /@ output]]},
+			specs["lagrangian"][#][f bf, t] /
+				specs["lagrangian"][#][f \[Pi] Sqrt[2], t]] & /@ output]]},
 	{bf, min, max, step}] & /@ {Min, Max},
 	Axes -> False,
 	Frame -> True,
 	FrameLabel -> {
-		"\!\(\*FormBox[\(\*SubscriptBox[\(b\), \(-\)]/f\), TraditionalForm]\)",
-		"\!\(\*FormBox[\(V/\*SubscriptBox[\(V\), \(max\)]\), TraditionalForm]\)"},
+		label[ratioLabel[specs["fieldLabel"], italicLabel["f"]]],
+		label[$label["fieldRangeUnitless", specs["fieldLabel"]]]},
 	PlotStyle -> ColorData[97, 1],
 	Joined -> True,
-	Filling -> {1 -> {2}}]
+	Filling -> {1 -> {2}},
+	PlotRange -> All]
 
 
-plot[{func_, p1_, p2_}, lagrangian_, output_] := func[
+plot[{"potential", parameters_, min_, max_}, specs_, output_] := Plot[
+	-specs["lagrangian"][parameters][b, t], {b, min, max},
+	PlotRange -> All,
+	Frame -> True,
+	FrameLabel -> {
+		label[ratioLabel[specs["fieldLabel"], planckMassLabel]],
+		label[ratioLabel[
+			italicLabel["V"], subscriptLabel[italicLabel["V"], plainLabel["0"]]]]}]
+
+
+plot[{func_, p1_, p2_}, specs_, output_] := func[
 	output[[All, {p1, p2}]],
 	PlotRange -> All,
 	Frame -> True,
 	FrameLabel -> label /@ {p1, p2}]
 
 
-plot["fStatic_fDynamic", lagrangian_, output_] := With[
-	{pointsPlot = plot[{ListPlot, "fStatic", "fDynamic"}, lagrangian, output]},
+plot["fStatic_fDynamic", specs_, output_] := With[
+	{pointsPlot = plot[{ListPlot, "fStatic", "fDynamic"}, specs["lagrangian"], output]},
 	Show[
 		Plot[
 			x,
@@ -188,15 +209,17 @@ plot["fStatic_fDynamic", lagrangian_, output_] := With[
 		pointsPlot]]
 
 
-plot["exitField_fStatic_ratio", lagrangian_, output_] := ListPlot[
+plot["fieldRange_fStatic_ratio", specs_, output_] := ListPlot[
 	Transpose[{
-		output[[All, "exitField"]] / output[[All, "fStatic"]],
-		output[[All, "exitField"]]}],
+		Abs[output[[All, "exitField"]] - output[[All, "endField"]]] /
+			output[[All, "fStatic"]],
+		Abs[output[[All, "exitField"]] - output[[All, "endField"]]]}],
 	PlotRange -> All,
 	Frame -> True,
 	FrameLabel -> {
-		traditionalLabel[ratioLabel[$label["exitFieldUnits"], $label["fStaticUnits"]]],
-		label["exitField"]}]
+		label[ratioLabel[
+			$label["fieldRange", specs["fieldLabel"]], $label["fStaticUnits"]]],
+		label[$label["fieldRangeUnitless", specs["fieldLabel"]]]}]
 
 
 (* ::Subsection:: *)
@@ -245,13 +268,13 @@ evaluateModel[modelSpecs_] := Module[{inputs, results},
 	inputs = generateInputs[
 		modelSpecs["parameterDistributions"],
 		"NP.coherent." <> modelSpecs["name"],
-		modelSpecs["pointCount"]];
+		Round[modelSpecs["pointCount"] pointCountMultiplier]];
 	Print[modelSpecs["name"] <> ": simulating inflation..."];
-	results = simulate[modelSpecs["lagrangian"], inputs];
+	results = simulate[
+		modelSpecs["lagrangian"], inputs, Lookup[modelSpecs, "evolutionOptions", {} &]];
 	Print["Found ", Length @ results, " points."];
 	Print[modelSpecs["name"] <> ": generating figures..."];
-	makeFigure[modelSpecs["name"], #, modelSpecs["lagrangian"], results] & /@
-		modelSpecs["figures"];
+	makeFigure[modelSpecs, #, results] & /@ modelSpecs["figures"];
 	Print[modelSpecs["name"] <> ": generating captions..."];
 	makeCaption[modelSpecs, results];
 	Print[modelSpecs["name"] <> ": done."];
@@ -286,18 +309,22 @@ supersymmetryLagrangian[f_, G_, B_: 1][bm_, t_] := 1/2 D[bm, t]^2 - 4 f^4 B^2 (
 )
 
 
+bMinusFieldLabel = subscriptLabel[italicLabel["b"], plainLabel["-"]]
+
+
 supersymmetrySpecs = <|
 	"name" -> "supersymmetry",
 	"lagrangian" -> (supersymmetryLagrangian[#["f"], {0, 0, 0, 1, #["G5"]}] &),
-	"pointCount" -> 20000 pointCountMultiplier,
+	"pointCount" -> 20000,
 	"parameterDistributions" -> Join[genericParameterDistributions, <|
 		"G5" -> UniformDistribution[{-0.88931, -0.88920}]|>],
 	"figures" -> {
 		{ListPlot, "f", "r"},
-		"exitField_fStatic_ratio",
+		"fieldRange_fStatic_ratio",
 		{ListPlot, "f", "fStatic"},
 		"fStatic_fDynamic",
 		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05}},
+	"fieldLabel" -> bMinusFieldLabel,
 	"caption" -> "Simulation results for the global supersymmetry model " <>
 		"Eq.~(\\ref{eq:supersymmetry:Vslow}). " <>
 		"Simulation consisted of a total of `totalPoints` points, out of which " <>
@@ -344,16 +371,17 @@ supergravitySpecs = <|
 	"name" -> "supergravity",
 	"lagrangian" ->
 		(supergravityLagrangian[#["f"], {1, 2, 3}, {1, #["A2"], #["A3"]}] &),
-	"pointCount" -> 70000 pointCountMultiplier,
+	"pointCount" -> 70000,
 	"parameterDistributions" -> Join[genericParameterDistributions, <|
 		"A2" -> UniformDistribution[{0.080, 0.085}],
 		"A3" -> UniformDistribution[{0.0030, 0.0037}]|>],
 	"figures" -> {
 		{ListPlot, "f", "r"},
-		"exitField_fStatic_ratio",
+		"fieldRange_fStatic_ratio",
 		{ListPlot, "f", "fStatic"},
 		"fStatic_fDynamic",
 		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05}},
+	"fieldLabel" -> bMinusFieldLabel,
 	"caption" -> "Simulation results for the supergravity model " <>
 		"Eq.~(\\ref{eq:supergravity:Vslow3}). " <>
 		"Simulation consisted of a total of `totalPoints` points, out of which " <>
@@ -370,42 +398,41 @@ supergravitySpecs = <|
 (*KKLT*)
 
 
-kkltLagrangian[f_, \[Gamma]_, W0_, A3_][a_, t_] := 1/2 D[a, t]^2 - Module[{B, \[ScriptCapitalA]3, C},
-	\[ScriptCapitalA]3 = Exp[-Sqrt[3 / 2] \[Gamma][[3]] / f] A3;
-	B[k_] := (\[Gamma][[k]] - \[Gamma][[3]]) \[ScriptCapitalA]3 + \[Gamma][[k]] W0;
-	Do[C[k] = \[Gamma][[k]] / (3 (\[Gamma][[3 - k]] - \[Gamma][[k]])) B[3 - k], {k, 1, 2}];
-	C[3] = -\[Gamma][[3]] / 3 \[ScriptCapitalA]3;
-	C[1, 2] = (Sqrt[2 / 3] \[Gamma][[1]] \[Gamma][[2]] + (\[Gamma][[1]] + \[Gamma][[2]]) f) /
-		(3 (\[Gamma][[1]] - \[Gamma][[2]])^2) B[1] B[2];
-	Do[C[k, 3] = (Sqrt[2 / 3] \[Gamma][[k]] \[Gamma][[3]] + (\[Gamma][[k]] + \[Gamma][[3]]) f) /
-		(3 (\[Gamma][[3 - k]] - \[Gamma][[k]])) \[ScriptCapitalA]3 B[3 - k], {k, 1, 2}];
-	f^2 W0 Sum[C[n] (1 - Cos[\[Gamma][[n]] a / f]), {n, 3}]
-		+ f Sum[C[n, m] (1 - Cos[(\[Gamma][[n]] - \[Gamma][[m]])a / f]), {n, 3}, {m, n + 1, 3}]
-]
+kkltPotential[\[Gamma]_, A_, W0_][\[Rho]_] := With[{\[Tau] = Exp[Sqrt[2 / 3] \[Rho]]},
+	A Exp[-2 \[Gamma] \[Tau]] \[Gamma] (3 Exp[\[Gamma] \[Tau]] W0 + A (3 + \[Gamma] \[Tau])) / (6 \[Tau]^2)]
+
+
+kkltLagrangianNormalized[\[Gamma]_, A_, W0_][\[Rho]_, t_] := With[
+	{minValue = 3 W0^2 \[Gamma]^3 / (
+		4 ProductLog[-1, 3 W0 / (2 A Exp[3 / 2])]^2
+		(3 + 2 ProductLog[-1, 3 W0 / (2 A Exp[3 / 2])]))},
+	1 / 2 D[\[Rho], t]^2 -
+		1 / (-minValue) (kkltPotential[\[Gamma], A, W0][\[Rho]] - minValue)]
 
 
 kkltSpecs = <|
 	"name" -> "kklt",
-	"lagrangian" -> (kkltLagrangian[#["f"], 2 Pi / {3, 4, 19}, 1.*^-12, 0.01] &),
-	"pointCount" -> 10000 pointCountMultiplier,
+	"lagrangian" -> (kkltLagrangianNormalized[\[Pi], -1, 10^#["logW0"]] &),
+	"pointCount" -> 1000,
 	"parameterDistributions" -> <|
-		"f" -> UniformDistribution[{0.9, 1}],
-		"fieldInitialOverF" -> UniformDistribution[{4, 7}],
+		"logW0" -> UniformDistribution[{-14, -10}],
+		"f" -> UniformDistribution[{1, 1}],
+		"fieldInitialOverF" -> UniformDistribution[{3.32, 3.32}],
 		"pivotEfoldings" -> UniformDistribution[{50, 60}]|>,
+	"evolutionOptions" -> ({"FieldFinal" ->
+		Sqrt[3/2] Log[-((3+2 ProductLog[-1,(3 10^#["logW0"])/(-2 E^(3/2))])/(2 \[Pi]))]} &),
 	"figures" -> {
-		{ListPlot, "f", "r"},
-		"exitField_fStatic_ratio",
-		{ListPlot, "f", "fStatic"},
+		{ListPlot, "pivotEfoldings", "r"},
+		"fieldRange_fStatic_ratio",
+		{ListPlot, "pivotEfoldings", "fStatic"},
 		"fStatic_fDynamic",
-		{"potentialRange", -1, 8, 0.1}},
+		{"potential", <|"logW0" -> -12|>, 2.76, 3.4}},
+	"fieldLabel" -> italicLabel["\[Rho]"],
 	"caption" -> "Simulation results for KKLT " <>
 		"Eq.~(\\ref{eq:KKLT:Vslow}). " <>
 		"Simulation consisted of a total of `totalPoints` points, out of which " <>
 		"`points` shown are consistent with experimental data on $r$ and $n_s$. " <>
-		"Here $\\gamma_1 = 2 \\pi / 3$, $\\gamma_2 = 2 \\pi / 4$, " <>
-		"$\\gamma_3 = 2 \\pi / 19$, " <>
-		"$W_0 = 10^{-12} M_\\text{P}^3$, " <>
-		"$A_3 = 0.01 M_\\text{P}^3$, " <>
+		"Here $W_0 = <*distribution[\"W0\"]*> M_\\text{P}^3$, " <>
 		"$f / M_\\text{P} \\sim <*distribution[\"f\", {2, 1}]*>$, " <>
 		"$a / f \\sim <*distribution[\"fieldInitialOverF\"]*>$, " <>
 		"$N_\\text{pivot} \\sim <*distribution[\"pivotEfoldings\"]*>$."|>;

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -48,6 +48,9 @@ generateInputs[parameterDistributions_, seed_, n_] :=
 (*Simulation*)
 
 
+minSubhorizonEfoldings = 5;
+
+
 simulate[lagrangian_, inputs_] := Module[{hash, filename, results, counter},
 	hash = Hash[{DownValues[simulate], lagrangian, inputs}];
 	filename = FileNameJoin[{cacheDirectory, IntegerString[hash, 16] <> ".wxf"}];
@@ -62,7 +65,13 @@ simulate[lagrangian_, inputs_] := Module[{hash, filename, results, counter},
 			result = If[
 				ExperimentallyConsistentInflationQ[
 					lagrangian[#][bm[t], t],
-					{bm[t], #["f"] #["fieldInitialOverF"], 0}, t, #["pivotEfoldings"]],
+					{bm[t], #["f"] #["fieldInitialOverF"], 0},
+					t,
+					#["pivotEfoldings"]] &&
+				InflationEfoldingsCount[
+					lagrangian[#][bm[t], t],
+					{bm[t], #["f"] #["fieldInitialOverF"], 0},
+					t] >= #["pivotEfoldings"] + minSubhorizonEfoldings,
 				Join[
 					#,
 					Association @ Thread[
@@ -128,23 +137,27 @@ $label["exitFieldUnits"] = subscriptLabel[italicLabel["\[CapitalDelta]b"], plain
 $label["exitField"] = ratioLabel[$label["exitFieldUnits"], planckMassLabel];
 
 
+figureName[name_String] := name <> ".pdf"
+figureName[{f_, p1_String, p2_String, args___}] := p1 <> "_" <> p2 <> ".pdf"
+figureName[{name_String, args___}] := name <> ".pdf"
+
+
 makeFigure[model_, name_, lagrangian_, output_, OptionsPattern[]] :=
 	Export[
 		FileNameJoin[{
 			figuresDirectory,
-			model <> "_" <>
-				If[StringQ[name], name, name[[2]] <> "_" <> name[[3]]] <> ".pdf"}],
+			model <> "_" <> figureName[name]}],
 		Show[
 			plot[name, lagrangian, output],
 			ImageSize -> OptionValue["imageSize"],
 			LabelStyle -> Directive[FontFamily -> OptionValue["fontFamily"]]]]
 
 
-plot["potentialRange", lagrangian_, output_] := ListPlot[
+plot[{"potentialRange", min_, max_, step_}, lagrangian_, output_] := ListPlot[
 	ParallelTable[{bf, #[
 		Evaluate[With[{f = #[["f"]]},
 			lagrangian[#][f bf, t] / lagrangian[#][f \[Pi] Sqrt[2], t]] & /@ output]]},
-	{bf, -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.02}] & /@ {Min, Max},
+	{bf, min, max, step}] & /@ {Min, Max},
 	Axes -> False,
 	Frame -> True,
 	FrameLabel -> {
@@ -284,7 +297,7 @@ supersymmetrySpecs = <|
 		"exitField_fStatic_ratio",
 		{ListPlot, "f", "fStatic"},
 		"fStatic_fDynamic",
-		"potentialRange"},
+		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05}},
 	"caption" -> "Simulation results for the global supersymmetry model " <>
 		"Eq.~(\\ref{eq:supersymmetry:Vslow}). " <>
 		"Simulation consisted of a total of `totalPoints` points, out of which " <>
@@ -340,7 +353,7 @@ supergravitySpecs = <|
 		"exitField_fStatic_ratio",
 		{ListPlot, "f", "fStatic"},
 		"fStatic_fDynamic",
-		"potentialRange"},
+		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05}},
 	"caption" -> "Simulation results for the supergravity model " <>
 		"Eq.~(\\ref{eq:supergravity:Vslow3}). " <>
 		"Simulation consisted of a total of `totalPoints` points, out of which " <>
@@ -354,10 +367,55 @@ supergravitySpecs = <|
 
 
 (* ::Section:: *)
+(*KKLT*)
+
+
+kkltLagrangian[f_, \[Gamma]_, W0_, A3_][a_, t_] := 1/2 D[a, t]^2 - Module[{B, \[ScriptCapitalA]3, C},
+	\[ScriptCapitalA]3 = Exp[-Sqrt[3 / 2] \[Gamma][[3]] / f] A3;
+	B[k_] := (\[Gamma][[k]] - \[Gamma][[3]]) \[ScriptCapitalA]3 + \[Gamma][[k]] W0;
+	Do[C[k] = \[Gamma][[k]] / (3 (\[Gamma][[3 - k]] - \[Gamma][[k]])) B[3 - k], {k, 1, 2}];
+	C[3] = -\[Gamma][[3]] / 3 \[ScriptCapitalA]3;
+	C[1, 2] = (Sqrt[2 / 3] \[Gamma][[1]] \[Gamma][[2]] + (\[Gamma][[1]] + \[Gamma][[2]]) f) /
+		(3 (\[Gamma][[1]] - \[Gamma][[2]])^2) B[1] B[2];
+	Do[C[k, 3] = (Sqrt[2 / 3] \[Gamma][[k]] \[Gamma][[3]] + (\[Gamma][[k]] + \[Gamma][[3]]) f) /
+		(3 (\[Gamma][[3 - k]] - \[Gamma][[k]])) \[ScriptCapitalA]3 B[3 - k], {k, 1, 2}];
+	f^2 W0 Sum[C[n] (1 - Cos[\[Gamma][[n]] a / f]), {n, 3}]
+		+ f Sum[C[n, m] (1 - Cos[(\[Gamma][[n]] - \[Gamma][[m]])a / f]), {n, 3}, {m, n + 1, 3}]
+]
+
+
+kkltSpecs = <|
+	"name" -> "kklt",
+	"lagrangian" -> (kkltLagrangian[#["f"], 2 Pi / {3, 4, 19}, 1.*^-12, 0.01] &),
+	"pointCount" -> 10000 pointCountMultiplier,
+	"parameterDistributions" -> <|
+		"f" -> UniformDistribution[{0.9, 1}],
+		"fieldInitialOverF" -> UniformDistribution[{4, 7}],
+		"pivotEfoldings" -> UniformDistribution[{50, 60}]|>,
+	"figures" -> {
+		{ListPlot, "f", "r"},
+		"exitField_fStatic_ratio",
+		{ListPlot, "f", "fStatic"},
+		"fStatic_fDynamic",
+		{"potentialRange", -1, 8, 0.1}},
+	"caption" -> "Simulation results for KKLT " <>
+		"Eq.~(\\ref{eq:KKLT:Vslow}). " <>
+		"Simulation consisted of a total of `totalPoints` points, out of which " <>
+		"`points` shown are consistent with experimental data on $r$ and $n_s$. " <>
+		"Here $\\gamma_1 = 2 \\pi / 3$, $\\gamma_2 = 2 \\pi / 4$, " <>
+		"$\\gamma_3 = 2 \\pi / 19$, " <>
+		"$W_0 = 10^{-12} M_\\text{P}^3$, " <>
+		"$A_3 = 0.01 M_\\text{P}^3$, " <>
+		"$f / M_\\text{P} \\sim <*distribution[\"f\", {2, 1}]*>$, " <>
+		"$a / f \\sim <*distribution[\"fieldInitialOverF\"]*>$, " <>
+		"$N_\\text{pivot} \\sim <*distribution[\"pivotEfoldings\"]*>$."|>;
+
+
+(* ::Section:: *)
 (*Evaluation*)
 
 
-evaluateModel /@ {supersymmetrySpecs, supergravitySpecs};
+evaluateModel /@ {supersymmetrySpecs, supergravitySpecs, kkltSpecs};
 
 
 Print["All done."];


### PR DESCRIPTION
## Paper text changes

* Adds requirement that at least 5 sub horizon e-foldings need to occur to classify a point as acceptable. If that is not done, points for which total and pivot number of e-foldings are too close to each other have initial conditions significantly affecting inflation evolution, which results into $f_e$ and $f_{eH}$ being inconsistent.
* Rewrites KKLT section to consider inflation along the real, instead of imaginary, direction.
* Adds a note about KKLT simulation results.

## Simulation code changes

* At least 5 sub horizon e-foldings are now required.
* Allows range specification in the model specs for "potentialRange" type plots.
* Adds KKLT simulations.