### PR TITLE
Update effective axion decay constant constraint with Planck 2018 data

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -165,17 +165,17 @@ We can thus eliminate $\eta$ and $\epsilon$ in favor of $n_s$ and $r$ and get
 \begin{equation}
   f_e = \frac{M_\text{P}}{\sqrt{1 - n_s - r / 4}}\,.
 \end{equation}
-The current experimental limits from Planck experiment at $k_0 = 0.05\,{\rm Mpc}^{-1}$ are as follows~\cite{Adam:2015rua, Ade:2015lrj, Array:2015xqh}
+The current experimental limits from Planck experiment at $k_0 = 0.05\,{\rm Mpc}^{-1}$ are as follows~\cite{Akrami:2018vks, Akrami:2018odb, Array:2015xqh}
 \begin{equation} \label{data}
   \begin{aligned}
-    n_s &= 0.9645 \pm 0.0049\, \left(68\%\, {\rm CL}\right)\,,\\
-      r &< 0.07\, \left(95\%\, {\rm CL}\right)\,,
+    n_s &= 0.9649 \pm 0.0042\, \left(68\%\, {\rm CL}\right)\,,\\
+      r &< 0.064\, \left(95\%\, {\rm CL}\right)\,,
   \end{aligned}
 \end{equation}
 while $n_t\left(k_0\right)$ is currently not constrained.
 Using this data we find model-independent bounds on the effective axionic decay constant so that
 \begin{equation} \label{eq:feExperimentalConstraint}
-  4.6 \leq f_e / M_\text{P} \leq 11\, \left(95\%\, {\rm CL}\right)\,.
+  4.8 \leq f_e / M_\text{P} \leq 9.7\, \left(95\%\, {\rm CL}\right)\,.
 \end{equation}
 
 Next, we discuss CEM for a superposition of cosine functions and show how the effective axion decay constant becomes super-Planckian even though the true decay constant is sub-Plankian.
@@ -832,19 +832,15 @@ This research was supported in part by the NSF Grant PHY-1620575.
   doi:10.1088/1126-6708/2008/03/014
   [arXiv:0709.0293 [hep-th]].
 
-\bibitem{Adam:2015rua}
-  R.~Adam {\it et al.} [Planck Collaboration],
-  %``Planck 2015 results. I. Overview of products and scientific results,''
-  Astron.\ Astrophys.\  {\bf 594}, A1 (2016)
-  doi:10.1051/0004-6361/201527101
-  [arXiv:1502.01582 [astro-ph.CO]].
+\bibitem{Akrami:2018vks}
+  Y.~Akrami {\it et al.} [Planck Collaboration],
+  %``Planck 2018 results. I. Overview and the cosmological legacy of Planck,''
+  arXiv:1807.06205 [astro-ph.CO].
 
-\bibitem{Ade:2015lrj}
-  P.~A.~R.~Ade {\it et al.} [Planck Collaboration],
-  %``Planck 2015 results. XX. Constraints on inflation,''
-  Astron.\ Astrophys.\  {\bf 594}, A20 (2016)
-  doi:10.1051/0004-6361/201525898
-  [arXiv:1502.02114 [astro-ph.CO]].
+\bibitem{Akrami:2018odb}
+  Y.~Akrami {\it et al.} [Planck Collaboration],
+  %``Planck 2018 results. X. Constraints on inflation,''
+  arXiv:1807.06211 [astro-ph.CO].
 
 \bibitem{Array:2015xqh}
   P.~A.~R.~Ade {\it et al.} [BICEP2 and Keck Array Collaborations],

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -34,8 +34,8 @@ We discuss the utility of this mechanism for a variety of axion potentials origi
 The coherent enhancement mechanism allows one to reduce an inflation model with an arbitrary potential to an effective model of natural inflation, i.e. with a single cosine, by expanding the potential near an inflationary point, and matching the expansion coefficients to those of natural inflation.
 We demonstrate that this approach can predict the number of e-foldings in a given inflation model without the need for numerical simulation.
 Further we show that the effective decay constant $f_e$ can be directly related to the spectral indices so that $f_e = M_\text{P} / \sqrt{1 - n_s - r / 4}$ where $n_s$ is the spectral index for curvature perturbations and $r$ is the ratio of the power spectrum of tensor perturbations and curvature perturbations.
-Thus the current data on $n_s$ and $r$ constrains the effective axion decay constant so that $4.6 \leq f_e / M_\text{P} \leq 11$ at $95\%$ CL.
-Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 11 M_\text{P}$ in units of Planck mass in axion cosmology for any potential-based model which produces successful inflation.
+Thus the current data on $n_s$ and $r$ constrains the effective axion decay constant so that $4.9 \leq f_e / M_\text{P} \leq 10.0$ at $95\%$ CL.
+Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 10 M_\text{P}$ in units of Planck mass in axion cosmology for any potential-based model which produces successful inflation.
 The coherent enhancement mechanism for the generation of an effective $f_e > M_\text{P}$ while the true axion decay constant $f < M_\text{P}$ is discussed.
 We illustrate the coherent enhancement in several settings: globally supersymmetric models, supergravity models, and the Large Volume Scenario.
 We also show that $f_e$ based on inflation dynamics can be defined for non-potential-based models, and consider a Dirac-Born-Infeld model as an example.
@@ -175,7 +175,7 @@ The current experimental limits from Planck experiment at $k_0 = 0.05\,{\rm Mpc}
 while $n_t\left(k_0\right)$ is currently not constrained.
 Using this data we find model-independent bounds on the effective axionic decay constant so that
 \begin{equation} \label{eq:feExperimentalConstraint}
-  4.8 \leq f_e / M_\text{P} \leq 9.7\, \left(95\%\, {\rm CL}\right)\,.
+  4.9 \leq f_e / M_\text{P} \leq 10.0\, \left(95\%\, {\rm CL}\right)\,.
 \end{equation}
 
 Next, we discuss CEM for a superposition of cosine functions and show how the effective axion decay constant becomes super-Planckian even though the true decay constant is sub-Plankian.


### PR DESCRIPTION
## Changes

* Updates the constraint on $f_e$ with Planck 2018 data.
* $f_e$ is now guaranteed to be real at 95% CL (which corresponds to concave potential), thus it has an upper bound at 95% CL.
* Bounds are computed using the following code and InflationSimulator v0.3.1:
```
DistributeDefinitions["InflationSimulator`"];
results = 
 Association@
  ParallelTable[
   If[ExperimentallyConsistentInflationQ[ns, r], {ns, r} -> 1/Sqrt[
     1 - ns - r/4], Nothing], {ns, 0.95, 0.98, 0.0001}, {r, 0, 0.08, 
    0.0001}];
MinMax[results]
```
* Also updates references to 2018 version of Planck paper.