### PR TITLE
Density plots for global supersymmetry and supergravity models

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -310,13 +310,18 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
     \includegraphics[width = \textwidth]{figures/supersymmetry_fStatic_fDynamic.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/supersymmetry_density.pdf}
+  \end{subfigure}
+  \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supersymmetry_potentialRange.pdf}
   \end{subfigure}
   \caption{\protect\input{figures/supersymmetry.txt}
     Top left panel shows tensor-to-scalar ratios we obtained.
     Top right panel demonstrates that the differences between the values of the field at horizon exit and at the end of inflation are always smaller than the effective decay constant $f_e$.
     Below, the panel on the left demonstrates the coherent enhancement of the decay constant, and the right panel compares effective decay constants computed from the potential and from the Hubble parameter, black line corresponds to $f_{eH} = f_e$.
-    Bottom panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
+    Bottom left panel shows the evolution of density $\rho$ as a function of the number of e-foldings $N$ until the end of inflation for an example with the largest tensor-to-scalar ratio $r$ in our sample.
+    One can see density is close to being constant at horizon exit, which implies $r \ll 1$.
+    Bottom right panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
     Note that because the field is normalized by $f$ and because $G_5$ is fine-tuned, potentials for all considered input parameters look almost identical.
     Inflation occurs in the flat region of the potential near $b_- / f \approx 3$.
   } \label{fig:supersymmetry}
@@ -479,6 +484,9 @@ Note, the Lyth bound~\cite{Lyth:1996im} for slow-roll inflation is satisfied in 
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supergravity_fStatic_fDynamic.pdf}
+  \end{subfigure}
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/supergravity_density.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supergravity_potentialRange.pdf}

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -236,6 +236,39 @@ plot["fieldRange_fStatic_ratio", specs_, output_] := ListPlot[
 			@ If[Length[specs["fieldLabels"]] == 1, specs["fieldLabels"][[1]], "\[Phi]"]]
 
 
+plot[{"density", sortingFunction_}, specs_, output_] := Module[{
+		chosenExample, L, time, evolution, densityFunction, initialDensity},
+	chosenExample = First @ SortBy[output, sortingFunction];
+	Print["Using example: ", chosenExample];
+	L = (specs["lagrangian"][#]
+			@@ Through[specs["initialConditions"][[All, 1]][time]])[time] &
+		@ chosenExample;
+	evolution = InflationEvolution[
+		L,
+		specs["initialConditions"] /. chosenExample,
+		time,
+		Lookup[specs, "evolutionOptions", {}]];
+	densityFunction =
+		InflatonDensity[L, Through[specs[["initialConditions"]][[All, 1]][time]], time]
+			/. evolution;
+	initialDensity = densityFunction /. time -> 0;
+	ParametricPlot[
+		Evaluate[{
+			evolution["Efoldings"][time] - evolution["TotalEfoldings"],
+			densityFunction / initialDensity}],
+		{time, 0, evolution["IntegrationTime"]},
+		PlotRange -> All,
+		Frame -> True,
+		AspectRatio -> 1 / GoldenRatio,
+		PlotPoints -> 1000,
+		FrameLabel -> {
+			label[italicLabel["N"]],
+			label[ratioLabel[
+				italicLabel["\[Rho]"],
+				subscriptLabel[italicLabel["\[Rho]"], plainLabel["0"]]]]}]
+]
+
+
 (* ::Subsection:: *)
 (*Figure captions*)
 
@@ -346,7 +379,8 @@ evaluateModel[<|
 		"fieldRange_fStatic_ratio",
 		{ListPlot, "f", "fStatic"},
 		"fStatic_fDynamic",
-		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05}},
+		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05},
+		{"density", -#["r"] &}},
 	"fieldLabels" -> <|bm -> bMinusFieldLabel|>,
 	"caption" -> "Simulation results for the global supersymmetry model " <>
 		"Eq.~(\\ref{eq:supersymmetry:Vslow}). " <>
@@ -400,7 +434,8 @@ evaluateModel[<|
 		"fieldRange_fStatic_ratio",
 		{ListPlot, "f", "fStatic"},
 		"fStatic_fDynamic",
-		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05}},
+		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05},
+		{"density", -#["r"] &}},
 	"fieldLabels" -> <|bm -> bMinusFieldLabel|>,
 	"caption" -> "Simulation results for the supergravity model " <>
 		"Eq.~(\\ref{eq:supergravity:Vslow3}). " <>


### PR DESCRIPTION
## Changes
* Partly addresses https://github.com/maxitg/coherent-enhancement/issues/19.
* Implements `"density"`-type plot, which plots the relative density as a function of the number of e-foldings for an example chosen according to the supplied comparison function.
* Adds density plots for global supersymmetry
![supersymmetry_density](https://user-images.githubusercontent.com/1479325/58387552-e77cfb00-7fd5-11e9-8a0e-b0ed765c76af.png)
and supergravity
![supergravity_density](https://user-images.githubusercontent.com/1479325/58387553-ea77eb80-7fd5-11e9-87a7-2788b8bd4ffa.png)
models for the cases with the largest value of tensor-to-scalar ratio $r$.

## Notes
* The density plot for DBI will come in a separate PR, the issue with it is that current version of InflationSimulator cannot reliably simulate DBI.

## Commands and tests
* Build the paper with `./build.sh` to get the following PDF:
[coherent-enhancement.pdf](https://github.com/maxitg/coherent-enhancement/files/3221131/coherent-enhancement.pdf)