### PR TITLE
DBI density plot

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -756,10 +756,14 @@ We then select parameter choices than produced at least $N_\text{pivot}$ number 
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/DBI_f_fDynamic.pdf}
   \end{subfigure}
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/DBI_density.pdf}
+  \end{subfigure}
   \caption{\protect\input{figures/DBI.txt}
     Top left panel is a plot of the ratio $r$ of the tensor to scalar power spectrum vs the scalar spectral index $n_s$.
     Top right panel shows the values of non-Gaussianity parameter $f_{NL}^\text{equil}$ as a function of $\alpha_1$.
-    Bottom panel shows that the values of the effective axion decay constant $f_{eH}$ are independent of the true axion decay constant $f$.} \label{fig:DBI}
+    Bottom left panel shows that the values of the effective axion decay constant $f_{eH}$ are independent of the true axion decay constant $f$.
+    Bottom right panel shows the density evolution for an example with the largest value of $r$ in our simulation, it specifically demonstrates that the density in this model does not stay constant during horizon exit unlike Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}), which leads to the values of $r$ close to the experimental limit.} \label{fig:DBI}
 \end{figure}
 
 % TODO(maxitg): Simulation part needs to be added here.

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -526,6 +526,54 @@ evaluateModel[<|
 Print["Starting DBI..."];
 
 
+dbi$maxADot[T_, \[Alpha]1_] :=
+	Module[{\[Alpha]1i}, Limit[2 T^(1/2) Sqrt[(Sqrt[2 \[Alpha]1i] - 2) / (2 \[Alpha]1i - 4)], \[Alpha]1i -> \[Alpha]1]]
+
+
+dbi$\[ScriptCapitalT][T_, \[Alpha]1_, ad_] := 1/2 (1 + Sqrt[1 - 4 ad^2 / T + 2 (2 - \[Alpha]1) ad^4 / T^2])
+
+
+dbi$k[\[Beta]_, f_, G_List, a_] := \[Beta] Sqrt[Sum[
+	m n G[[m]] G[[n]] (1 - Cos[a m / f] - Cos[a n / f] + Cos[a (m - n) / f]),
+	{m, Length[G]},
+	{n, Length[G]}]]
+
+
+dbi$\[ScriptCapitalF][T_, \[Alpha]1_, k_, \[ScriptCapitalT]_, ad_, s_] := s Power[
+	-s 1 / (2 \[Alpha]1) k (\[ScriptCapitalT] - ad^2 / T)
+		+ Sqrt[
+			1 / (4 \[Alpha]1^2) k^2 (\[ScriptCapitalT] - ad^2 / T)^2
+				+ 1 / (27 \[Alpha]1^3) (\[ScriptCapitalT] + (\[Alpha]1 - 1) ad^2 / T)^3],
+	1 / 3]
+
+
+dbi$\[ScriptCapitalL][T_, \[Alpha]1_, \[ScriptCapitalT]_, k_, \[ScriptCapitalF]Plus_, \[ScriptCapitalF]Minus_, ad_] := T (
+	1
+		- Sqrt[1 - 4 ad^2 / T + 2 (2 - \[Alpha]1) ad^4 / T^2]
+		+ 2 \[ScriptCapitalF]Plus^2
+		+ 2 \[ScriptCapitalF]Minus^2
+		- 4 / (3 \[Alpha]1) (\[ScriptCapitalT] + (\[Alpha]1 - 1) ad^2 / T)
+		+ 4 k (\[ScriptCapitalF]Plus + \[ScriptCapitalF]Minus)
+		+ \[Alpha]1 / (\[ScriptCapitalT] - ad^2 / T) (
+			2 (\[ScriptCapitalF]Plus^2 + \[ScriptCapitalF]Minus^2 - 2 / (3 \[Alpha]1) (\[ScriptCapitalT] + (\[Alpha]1 - 1) ad^2 / T)) ad^2 / T
+				+ \[ScriptCapitalF]Plus^4
+				+ \[ScriptCapitalF]Minus^4
+				+ 2 / (3 \[Alpha]1^2) (\[ScriptCapitalT] + (\[Alpha]1 - 1) ad^2 / T)^2
+				- 4 / (3 \[Alpha]1) (\[ScriptCapitalT] + (\[Alpha]1 - 1) ad^2 / T) (\[ScriptCapitalF]Plus^2 + \[ScriptCapitalF]Minus^2)))
+
+
+dbiLagrangian[T_, \[Alpha]1_, f_, \[Beta]_, G_][am_][t_] := Module[
+		{\[ScriptCapitalT], a, ad, k, \[ScriptCapitalF]Plus, \[ScriptCapitalF]Minus},
+	ad = D[am, t] / 2;
+	a = am / 2;
+	\[ScriptCapitalT] = dbi$\[ScriptCapitalT][T, \[Alpha]1, ad];
+	k = dbi$k[\[Beta], f, G, a];
+	\[ScriptCapitalF]Plus = dbi$\[ScriptCapitalF][T, \[Alpha]1, k, \[ScriptCapitalT], ad, +1];
+	\[ScriptCapitalF]Minus = dbi$\[ScriptCapitalF][T, \[Alpha]1, k, \[ScriptCapitalT], ad, -1];
+	dbi$\[ScriptCapitalL][T, \[Alpha]1, \[ScriptCapitalT], k, \[ScriptCapitalF]Plus, \[ScriptCapitalF]Minus, ad]
+]
+
+
 Print["DBI: Reading simulation results..."];
 
 
@@ -553,12 +601,17 @@ aMinusFieldLabel = subscriptLabel[italicLabel["a"], plainLabel["-"]];
 
 dbiSpecs = <|
 	"name" -> "DBI",
+	"lagrangian" ->
+		(dbiLagrangian[#["T"], #["Alpha1"], #["f"], #["\[Beta]"], #["G"]] &),
+	"initialConditions" -> {{am, "FieldInitial", "FieldTimeDerivativeInitial"}},
 	"pointCount" -> Length[dbiFilteredWithFDynamic],
+	"evolutionOptions" -> {"FinalDensityPrecisionGoal" -> 2},
 	"figures" -> {
 		"ns_r",
 		{ListLogLogPlot, "Alpha1", "NonGaussianityAmplitude"},
-		{ListPlot, "f", "fDynamic"}},
-	"fieldLabels" -> <|bm -> aMinusFieldLabel|>,
+		{ListPlot, "f", "fDynamic"},
+		{"density", -#["TensorToScalarRatio"] &}},
+	"fieldLabels" -> <|am -> aMinusFieldLabel|>,
 	"caption" -> "Simulation results for the DBI model " <>
 		"Eq.~(\\ref{eq:dbi:lagrangian}). " <>
 		"Simulation consisted of the same $0.5 \\times 10^6$ points as " <>


### PR DESCRIPTION
## Changes
* Resolves #19.
* Adds DBI Lagrangian definition to `./computeSimulations.wls`.
* Adds the density plot for DBI and a corresponding caption:
<img width="466" alt="Screen Shot 2019-05-26 at 20 56 13" src="https://user-images.githubusercontent.com/1479325/58390807-b5c95b80-7ff8-11e9-885c-da73bc6a2f6b.png">

## Commands and tests
* Build the paper with `./build.sh` to get the following PDF:
[coherent-enhancement.pdf](https://github.com/maxitg/coherent-enhancement/files/3221524/coherent-enhancement.pdf)