### PR TITLE
pointCloudMultiplier argument

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-./computeSimulations.wls &&
+pointCountMultiplier=1.0
+while getopts p: option
+do
+  case "${option}"
+    in
+    p) pointCountMultiplier=${OPTARG};;
+  esac
+done
+
+./computeSimulations.wls $pointCountMultiplier &&
 pdflatex coherent-enhancement.tex &&
 pdflatex coherent-enhancement.tex &&
 pdflatex coherent-enhancement.tex

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -173,7 +173,7 @@ makeFigure[specs_, name_, output_, OptionsPattern[]] := (
 plot[{"potentialRange", min_, max_, step_}, specs_, output_] := ListPlot[
 	If[Length[specs["initialConditions"]] != 1,
 		Print["potentialRange can only be plotted for single field models."];
-		Quit[]];
+		Quit[-1]];
 	ParallelTable[{bf, #[
 		Evaluate[With[{f = #[["f"]]},
 			specs["lagrangian"][#][f bf][t] /
@@ -193,7 +193,7 @@ plot[{"potentialRange", min_, max_, step_}, specs_, output_] := ListPlot[
 plot[{"potential", parameters_, min_, max_}, specs_, output_] := Plot[
 	If[Length[specs["initialConditions"]] != 1,
 		Print["potentialRange can only be plotted for single field models."];
-		Quit[]];
+		Quit[-1]];
 	-specs["lagrangian"][parameters][b][t], {b, min, max},
 	PlotRange -> All,
 	Frame -> True,
@@ -336,7 +336,12 @@ evaluateModel[modelSpecs_] := Module[{inputs, results, time},
 (*Global parameters*)
 
 
-pointCountMultiplier = 1;
+pointCountMultiplier = If[Length[$ScriptCommandLine] >= 2,
+	ToExpression @ $ScriptCommandLine[[2]],
+	1];
+If[!NumericQ[pointCountMultiplier],
+	Print["pointCountMultiplier must be a numeric value."];
+	Quit[-1];]
 
 
 genericParameterDistributions = <|


### PR DESCRIPTION
## Changes
* Allows specifying `pointCloudMultiplier` as an argument for `./build.sh` and `./computeSimulations.wls`.
* This is useful for development, because a version of the paper with a small number of simulated points can be build quickly, i.e., `./build -p 0.1` will build the paper ~10 times faster, which allows for faster iterations.

## Tests and commands
* Try building with different values, i.e., `./build.sh -p 0.01`, `./build.sh -p 0.1` and `./build.sh`.
* Observe that a different number of points is being produced in each case.