### PR TITLE
Remove field range plots

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -301,9 +301,6 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
     \includegraphics[width = \textwidth]{figures/supersymmetry_ns_r.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/supersymmetry_fieldRange_fStatic_ratio.pdf}
-  \end{subfigure}
-  \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supersymmetry_f_fStatic.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
@@ -318,12 +315,12 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
   \caption{\protect\input{figures/supersymmetry.txt}
     Top left panel shows tensor-to-scalar ratios vs. scalar spectral indices we obtained.
     Blue region encloses the values consistent with Planck 2018 TT,TE,EE+lowE+lensing+BK14+BAO data at $95\%$ CL.
-    Top right panel demonstrates that the differences between the values of the field at horizon exit and at the end of inflation are always smaller than the effective decay constant $f_e$.
-    Below, the panel on the left demonstrates the coherent enhancement of the decay constant, and the right panel compares effective decay constants computed from the potential and from the Hubble parameter, black line corresponds to $f_{eH} = f_e$.
-    Bottom left panel shows the evolution of density $\rho$ as a function of the number of e-foldings $N$ until the end of inflation for an example with the largest tensor-to-scalar ratio $r$ in our sample.
+    Top right panel demonstrates the coherent enhancement of the decay constant, and the middle left panel compares effective decay constants computed from the potential and from the Hubble parameter, black line corresponds to $f_{eH} = f_e$.
+    Middle right panel shows the evolution of density $\rho$ as a function of the number of e-foldings $N$ until the end of inflation for an example with the largest tensor-to-scalar ratio $r$ in our sample.
     One can see density is close to being constant at horizon exit, which implies $r \ll 1$.
-    Bottom right panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
+    Bottom panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
     Note that because the field is normalized by $f$ and because $G_5$ is fine-tuned, potentials for all considered input parameters look almost identical.
+    Also note that the field change during inflation $\Delta b_- < f \le M_\text{P}$.
     Inflation occurs in the flat region of the potential near $b_- / f \approx 3$.
   } \label{fig:supersymmetry}
 \end{figure}
@@ -476,9 +473,6 @@ Note, the Lyth bound~\cite{Lyth:1996im} for slow-roll inflation is satisfied in 
   \centering
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supergravity_ns_r.pdf}
-  \end{subfigure}
-  \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/supergravity_fieldRange_fStatic_ratio.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supergravity_f_fStatic.pdf}

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -79,13 +79,7 @@ simulate[lagrangian_, initialConditions_, inputs_, options_] := Module[
 				Join[
 					#,
 					Association @ Thread[
-						{"fDynamic",
-								"r",
-								"ns",
-								"exitFields",
-								"endFields",
-								"fStatic",
-								"consistentQ"} ->
+						{"fDynamic", "r", "ns", "exitFields", "fStatic", "consistentQ"} ->
 							Join[
 								exitValues = InflationValue[
 									L,
@@ -97,13 +91,6 @@ simulate[lagrangian_, initialConditions_, inputs_, options_] := Module[
 										"ScalarSpectralIndex",
 										initialConditions[[All, 1]]},
 									"HorizonExit"],
-								InflationValue[
-									L,
-									evolution,
-									t,
-									#["pivotEfoldings"],
-									{initialConditions[[All, 1]]},
-									"End"],
 								InflatonLagrangianValue[
 									L,
 									Transpose[
@@ -152,9 +139,6 @@ $label["fStaticUnits"] = subscriptLabel[italicLabel["f"], italicLabel["e"]];
 $label["fStatic"] = ratioLabel[$label["fStaticUnits"], planckMassLabel];
 $label["fDynamic"] =
 	ratioLabel[subscriptLabel[italicLabel["f"], italicLabel["eH"]], planckMassLabel];
-$label["fieldRange", field_] := rowLabel[{italicLabel["\[CapitalDelta]"], field}];
-$label["fieldRangeUnitless", field_] :=
-	ratioLabel[$label["fieldRange", field], planckMassLabel];
 $label["pivotEfoldings"] = subscriptLabel[italicLabel["N"], plainLabel["pivot"]];
 $label["VNormalized"] = ratioLabel[
 	italicLabel["V"], subscriptLabel[italicLabel["V"], plainLabel["max"]]];
@@ -274,28 +258,6 @@ plot["fStatic_fDynamic", specs_, output_] := With[
 			FrameLabel -> {label["fStatic"], label["fDynamic"]},
 			Evaluate @ AbsoluteOptions[pointsPlot, PlotRange]],
 		pointsPlot]]
-
-
-plot["fieldRange_fStatic_ratio", specs_, output_] := Module[{consistentOutput},
-	consistentOutput = Select[#["consistentQ"] &][output];
-	ListPlot[
-		Transpose[{
-			Norm /@ (consistentOutput[[All, "exitFields"]]
-					- consistentOutput[[All, "endFields"]]) /
-				consistentOutput[[All, "fStatic"]],
-			Norm /@ (consistentOutput[[All, "exitFields"]]
-					- consistentOutput[[All, "endFields"]])}],
-		PlotRange -> All,
-		PlotStyle -> ColorData[97, 3],
-		Frame -> True,
-		FrameLabel -> {
-			label[ratioLabel[
-				$label["fieldRange", #], $label["fStaticUnits"]]],
-			label[$label["fieldRangeUnitless", #]]} &
-				@ If[
-					Length[specs["fieldLabels"]] == 1,
-					specs["fieldLabels"][[1]],
-					"\[Phi]"]]]
 
 
 plot[{"density", sortingFunction_}, specs_, output_] := Module[{
@@ -444,7 +406,6 @@ evaluateModel[<|
 		"G5" -> UniformDistribution[{-0.88931, -0.88920}]|>],
 	"figures" -> {
 		"ns_r",
-		"fieldRange_fStatic_ratio",
 		{ListPlot, "f", "fStatic"},
 		"fStatic_fDynamic",
 		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05},
@@ -500,7 +461,6 @@ evaluateModel[<|
 		"A3" -> UniformDistribution[{0.0030, 0.0037}]|>],
 	"figures" -> {
 		"ns_r",
-		"fieldRange_fStatic_ratio",
 		{ListPlot, "f", "fStatic"},
 		"fStatic_fDynamic",
 		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05},


### PR DESCRIPTION
## Changes
* Closes #21.
* Removes the plots of field ranges.
* Adds a note saying the fields during inflation roll less than $f < M_\text{P}$.

## Commands and tests
* Build the paper with `./build.sh -p 0.1` (`-p 0.1` means the number of points is reduced 10x) to see the new arrangement of plots:
[coherent-enhancement.pdf](https://github.com/maxitg/coherent-enhancement/files/3224616/coherent-enhancement.pdf)