### PR TITLE
Remove plots comparing $f_e$ and $f_{eH}$

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -331,6 +331,7 @@ If so, we evaluate $f_e$ and $f_{eH}$ at horizon exit using Eqs.~(\ref{eq:feFrom
 The results of this process can be seen on Fig.~(\ref{fig:supersymmetry}).
 
 One can see that even though true decay constant $f$ is below $M_\text{P}$, the effective $f_e \approx f_{eH}$ always satisfy constraint \ref{eq:feExperimentalConstraint}.
+We find the relative difference between two effective decay constants $\left|f_e - f_{eH}\right| / f_e \le \protect\input{figures/supersymmetryfRelativeDifferenceMax.txt}$.
 Note, fine tuning of $G_5$ is required to achieve coherent enhancement and experimentally-consistent inflation.
 
 \section{Enhancement mechanism in supergravity \label{sec:Supergravity}}
@@ -465,6 +466,7 @@ Note, the Lyth bound~\cite{Lyth:1996im} for slow-roll inflation is satisfied in 
 \begin{equation} \label{eq:lyth}
   \frac{\Delta \phi}{M_\text{P}} \ge \left(\frac{r}{0.01}\right)^{1/2}\,.
 \end{equation}
+In this model, we find $\left|f_e - f_{eH}\right| / f_e \le \protect\input{figures/supergravityfRelativeDifferenceMax.txt}$.
 
 \begin{figure}
   \centering

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -304,9 +304,6 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
     \includegraphics[width = \textwidth]{figures/supersymmetry_f_fStatic.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/supersymmetry_fStatic_fDynamic.pdf}
-  \end{subfigure}
-  \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supersymmetry_density.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
@@ -315,10 +312,10 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
   \caption{\protect\input{figures/supersymmetry.txt}
     Top left panel shows tensor-to-scalar ratios vs. scalar spectral indices we obtained.
     Blue region encloses the values consistent with Planck 2018 TT,TE,EE+lowE+lensing+BK14+BAO data at $95\%$ CL.
-    Top right panel demonstrates the coherent enhancement of the decay constant, and the middle left panel compares effective decay constants computed from the potential and from the Hubble parameter, black line corresponds to $f_{eH} = f_e$.
-    Middle right panel shows the evolution of density $\rho$ as a function of the number of e-foldings $N$ until the end of inflation for an example with the largest tensor-to-scalar ratio $r$ in our sample.
+    Top right panel demonstrates the coherent enhancement of the decay constant.
+    Below, left panel shows the evolution of density $\rho$ as a function of the number of e-foldings $N$ until the end of inflation for an example with the largest tensor-to-scalar ratio $r$ in our sample.
     One can see density is close to being constant at horizon exit, which implies $r \ll 1$.
-    Bottom panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
+    Bottom right panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
     Note that because the field is normalized by $f$ and because $G_5$ is fine-tuned, potentials for all considered input parameters look almost identical.
     Also note that the field change during inflation $\Delta b_- < f \le M_\text{P}$.
     Inflation occurs in the flat region of the potential near $b_- / f \approx 3$.
@@ -476,9 +473,6 @@ Note, the Lyth bound~\cite{Lyth:1996im} for slow-roll inflation is satisfied in 
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supergravity_f_fStatic.pdf}
-  \end{subfigure}
-  \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/supergravity_fStatic_fDynamic.pdf}
   \end{subfigure}
   \begin{subfigure}{0.45 \textwidth}
     \includegraphics[width = \textwidth]{figures/supergravity_density.pdf}

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -244,22 +244,6 @@ plot["ns_r", specs_, output_] := Module[{
 		FrameLabel -> label /@ {"ns", "r"}]]
 
 
-plot["fStatic_fDynamic", specs_, output_] := With[
-	{pointsPlot = plot[
-		{ListPlot, "fStatic", "fDynamic"},
-		specs["lagrangian"],
-		Select[#["consistentQ"] &][output]]},
-	Show[
-		Plot[
-			x,
-			{x, 0, 10},
-			PlotStyle -> Black,
-			Frame -> True,
-			FrameLabel -> {label["fStatic"], label["fDynamic"]},
-			Evaluate @ AbsoluteOptions[pointsPlot, PlotRange]],
-		pointsPlot]]
-
-
 plot[{"density", sortingFunction_}, specs_, output_] := Module[{
 		chosenExample, L, time, evolution, densityFunction, initialDensity},
 	chosenExample = First @ SortBy[Select[#["consistentQ"] &][output], sortingFunction];
@@ -407,7 +391,6 @@ evaluateModel[<|
 	"figures" -> {
 		"ns_r",
 		{ListPlot, "f", "fStatic"},
-		"fStatic_fDynamic",
 		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05},
 		{"density", -#["r"] &}},
 	"fieldLabels" -> <|bm -> bMinusFieldLabel|>,
@@ -462,7 +445,6 @@ evaluateModel[<|
 	"figures" -> {
 		"ns_r",
 		{ListPlot, "f", "fStatic"},
-		"fStatic_fDynamic",
 		{"potentialRange", -0.1 Pi Sqrt[2], 1.1 Pi Sqrt[2], 0.05},
 		{"density", -#["r"] &}},
 	"fieldLabels" -> <|bm -> bMinusFieldLabel|>,

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -315,6 +315,17 @@ makeCaption[specs_, results_] := Export[
 				"points" -> Length @ Select[#["consistentQ"] &] @ results|>]]
 
 
+makeFStaticFDynamicComparisonText[specs_, results_] := With[{
+	consistentResults = Select[#["consistentQ"] &][results]},
+	Export[
+		FileNameJoin[{figuresDirectory, specs["name"] <> "fRelativeDifferenceMax.txt"}],
+		ToString[Ceiling[100 Max[Abs[
+				1 - consistentResults[[All, "fDynamic"]]
+					/ consistentResults[[All, "fStatic"]]]]]]
+			<> "\\%"]
+]
+
+
 (* ::Subsection:: *)
 (*Evaluator*)
 
@@ -336,6 +347,7 @@ evaluateModel[modelSpecs_] := Module[{inputs, results, time},
 	Print[modelSpecs["name"] <> ": generating figures..."];
 	makeFigure[modelSpecs, #, results] & /@ modelSpecs["figures"];
 	Print[modelSpecs["name"] <> ": generating captions..."];
+	makeFStaticFDynamicComparisonText[modelSpecs, results];
 	makeCaption[modelSpecs, results];
 	Print[modelSpecs["name"] <> ": done."];
 ]


### PR DESCRIPTION
## Changes
* Closes #22.
* Removes `"fStatic_fDynamic"` type of plot, and corresponding figures from the .tex file.
* Adds computation of max relative difference between $f_e$ and $f_{eH}$, and adds corresponding notes to the text:
<img width="935" alt="Screen Shot 2019-05-27 at 16 37 45" src="https://user-images.githubusercontent.com/1479325/58440161-c4b61980-809d-11e9-9146-acd32ca775af.png">

## Tests and commands
* Build the paper with `./build.sh` to get the following pdf:
[coherent-enhancement.pdf](https://github.com/maxitg/coherent-enhancement/files/3225015/coherent-enhancement.pdf)