### PR TITLE
Fix mistakes in DBI equations

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -564,11 +564,11 @@ The supersymmetric Lagrangian involving $\Phi_1$ and $\Phi_2$ is given by
 where $\mathcal{L}_D$ is the $D$-part of the Lagrangian and $\mathcal{L}_F$ is the $F$-part.
 Here $\mathcal{L}_D$ consists of a part which is quadratic in the fields and a part which is quartic in the fields so that
 \begin{equation} \label{eq:DBI:lagrangianD}
-  \mathcal{L}_D = \int d^4 \theta \left(\Phi_1 \Phi_1^\dagger + \Phi_2 \Phi_2^\dagger\right)
+  \mathcal{L}_D = \sum_{k = 1}^2 \left(\int d^4 \theta \Phi_k \Phi_k^\dagger
     + \int d^4 \theta \frac{\alpha_1}{16 T}
-      \left(D^\alpha \Phi_1 D_\alpha \Phi_1\right)
-      \left({\bar D}^{\dot\alpha} \Phi_1^\dagger {\bar D}_{\dot\alpha} \Phi_1^\dagger\right)
-      G\left(\phi\right)\,,
+      \left(D^\alpha \Phi_k D_\alpha \Phi_k\right)
+      \left({\bar D}^{\dot\alpha} \Phi_k^\dagger {\bar D}_{\dot\alpha} \Phi_k^\dagger\right)
+      G\left(\phi\right)\right)\,,
 \end{equation}
 where
 \begin{equation}
@@ -597,7 +597,11 @@ Finally $\mathcal{L}_F$ is given by
   \mathcal{L}_F = \int d^2 \theta W\left(\Phi_1, \Phi_2\right)
                 + \int d^2 \bar\theta W^*\left(\Phi_1^\dagger, \Phi_2^\dagger\right)\,,
 \end{equation}
-where the superpotential $W$ as in earlier analyses is given by $W = W_s + W_{sb}$, and where $W_s$ is chosen so that we can stabilize the saxion VEVs and $W_{sb}$ breaks the global $U\left(1\right)$ symmetry and is taken to be of the form
+where the superpotential $W$ as in earlier analyses is given by $W = W_s + W_{sb}$, and where
+\begin{equation}
+W_s = \mu \Phi_1 \Phi_2 + \frac{\lambda}{2} \left(\Phi_1 \Phi_2\right)^2
+\end{equation}
+is chosen so that we can stabilize the saxion VEVs and $W_{sb}$ breaks the global $U\left(1\right)$ symmetry and is taken to be of the form
 \begin{equation} \label{eq:dbi:Wsb}
   W_{sb} = \sum_{k = 1}^m \left(A_{1, k} \Phi_1^k + A_{2, k} \Phi_2^k\right)\,.
 \end{equation}
@@ -667,7 +671,7 @@ Thus we have
       - \sqrt{
           1
         - \frac{{\dot b}_-^2}{T}
-        + \frac{\left(2 - \alpha_1\right) {\dot b}_-^2}{8 T^2}
+        + \frac{\left(2 - \alpha_1\right) {\dot b}_-^4}{8 T^2}
       }\right.\\
       &~~~ \left.{}
       + 2 \mathcal{F}_+^2
@@ -708,7 +712,7 @@ where
           + \left(\alpha_1 - 1\right) \frac{{\dot b}_-^2}{4 T}
         \right)^3
       }
-    \right) \mathit{p}^{1 / 3}\,,
+    \right)^{1 / 3}\,,
   \end{aligned}
 \end{equation}
 and where


### PR DESCRIPTION
## Changes
* Closes #25.
* Add the missing term involving the second field to `eq:DBI:lagrangianD` (54).
<img width="683" alt="Screen Shot 2019-05-30 at 15 15 57" src="https://user-images.githubusercontent.com/1479325/58661581-d42ba180-82ed-11e9-8541-9422da8af1b3.png">

* Add definition of $W_s$ (58).
<img width="487" alt="Screen Shot 2019-05-30 at 15 16 24" src="https://user-images.githubusercontent.com/1479325/58661605-e60d4480-82ed-11e9-86ff-0e96158c2414.png">

* Fix the wrong power under the square root in the kinetic term of `eq:dbi:lagrangian` (64).
<img width="310" alt="Screen Shot 2019-05-30 at 15 16 42" src="https://user-images.githubusercontent.com/1479325/58661626-f0c7d980-82ed-11e9-9657-67849b5ea5cf.png">

* Remove a spurious p from the equation for `F±` (65).
<img width="661" alt="Screen Shot 2019-05-30 at 15 16 54" src="https://user-images.githubusercontent.com/1479325/58661636-f6bdba80-82ed-11e9-8e9a-fb7a85ec098d.png">

## Tests and commands
* Build the paper with `./build.sh` and check that the typos described above are fixed.