### PR TITLE
Reference `sec:r` in introduction

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -462,10 +462,6 @@ where $C_k$ are given by
 \end{equation}
 
 Simulation results for this potential are similar to the global supersymmetry model and are shown on Fig.~(\ref{fig:supergravity}).
-Note, the Lyth bound~\cite{Lyth:1996im} for slow-roll inflation is satisfied in this model as can be seen on the top left panel (which is also true for the global supersymmetry model considered above):
-\begin{equation} \label{eq:lyth}
-  \frac{\Delta \phi}{M_\text{P}} \ge \left(\frac{r}{0.01}\right)^{1/2}\,.
-\end{equation}
 In this model, we find $\left|f_e - f_{eH}\right| / f_e \le \protect\input{figures/supergravityfRelativeDifferenceMax.txt}$.
 
 \begin{figure}
@@ -793,7 +789,7 @@ where we used the definition of the slow-roll parameter $\epsilon$, see Eq.~(\re
   } \label{fig:density}
 \end{figure}
 
-If we now require $\Delta \phi < M_\text{P}$, which for types of models we consider implies $f \lesssim M_\text{P}$, we get
+If we now require $\Delta \phi < M_\text{P}$, which for types of models we consider implies $f \lesssim M_\text{P}$, we get the Lyth bound~\cite{Lyth:1996im}
 \begin{equation}
   r < \frac{8 \Delta \phi^2}{M_\text{P}^2 N^2} \lesssim 0.003\,,
 \end{equation}

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -1063,13 +1063,6 @@ This research was supported in part by the NSF Grant PHY-1620575.
   Nucl.\ Phys.\ B {\bf 227}, 121 (1983).
   doi:10.1016/0550-3213(83)90145-1
 
-\bibitem{Lyth:1996im}
-  D.~H.~Lyth,
-  %``What would we learn by detecting a gravitational wave signal in the cosmic microwave background anisotropy?,''
-  Phys.\ Rev.\ Lett.\  {\bf 78}, 1861 (1997)
-  doi:10.1103/PhysRevLett.78.1861
-  [hep-ph/9606387].
-
 \bibitem{Kachru:2003aw}
   S.~Kachru, R.~Kallosh, A.~D.~Linde and S.~P.~Trivedi,
   %``De Sitter vacua in string theory,''
@@ -1160,6 +1153,13 @@ This research was supported in part by the NSF Grant PHY-1620575.
   JHEP {\bf 1902}, 034 (2019)
   doi:10.1007/JHEP02(2019)034
   [arXiv:1807.02549 [hep-ph]].
+
+\bibitem{Lyth:1996im}
+  D.~H.~Lyth,
+  %``What would we learn by detecting a gravitational wave signal in the cosmic microwave background anisotropy?,''
+  Phys.\ Rev.\ Lett.\  {\bf 78}, 1861 (1997)
+  doi:10.1103/PhysRevLett.78.1861
+  [hep-ph/9606387].
 
 \bibitem{ArkaniHamed:2006dz}
   N.~Arkani-Hamed, L.~Motl, A.~Nicolis and C.~Vafa,

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -64,6 +64,7 @@ We exhibit the coherent enhancement in various settings.
 Thus in section \ref{sec:Supersymmetry} we discuss this mechanism in globally supersymmetric models, in section \ref{sec:Supergravity} for supergravity models, and in section \ref{sec:LVS} for a model inspired by the Large Volume Scenario.
 In section \ref{sec:DBI}, we discuss the Dirac-Born-Infeld case, in which inflation is not controlled by the potential alone but by the full Lagrangian.
 However, an effective decay constant $f_{eH}$ can still be defined based on inflation dynamics.
+In section \ref{sec:r}, we discuss the mechanism by which ratios $r$ of tensor-to-scalar power spectra are necessarily small in global supersymmetry and supergravity models we considered, and why they can be as large as experimental limit in DBI.
 In section \ref{sec:WeakGravityConjecture} we discuss the weak gravity conjecture and axion inflation.
 Conclusions are given in section \ref{sec:Conclusion}.
 Some relevant papers related to this work can be found in \cite{BlancoPillado:2006he, Conlon:2005jm, Ben-Dayan:2014lca, Gao:2014uha}.


### PR DESCRIPTION
## Changes
* Closes #41.
* Adds a reference to `sec:r` in introduction.
* Moves the reference to Lyth bound from `sec:supergravity` to `sec:r`, where it is essentially rederived.

## Commands and tests
* Build with `./build.sh` to get the PDF:
[coherent-enhancement.pdf](https://github.com/maxitg/coherent-enhancement/files/3239726/coherent-enhancement.pdf)