### PR TITLE
Note about DBI simulations

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -753,7 +753,9 @@ We then select parameter choices than produced at least $N_\text{pivot}$ number 
     Bottom panel shows that the values of the effective axion decay constant $f_{eH}$ are independent of the true axion decay constant $f$.} \label{fig:DBI}
 \end{figure}
 
-% TODO(maxitg): Simulation part needs to be added here.
+Simulation results for DBI are shown on Fig.~(\ref{fig:DBI}).
+Here we reuse the simulation results displayed in Fig~(1) of~\cite{Nath:2018xxe}, however, we update experimental constraints on tensor-to-scalar ratio $r$ and scalar spectral index $n_s$ to Planck 2018 results~\cite{Akrami:2018odb}, and compute the values of $f_{eH}$ using Eq.~(\ref{eq:feSpectralIndices}).
+Note that even though $f_e$ cannot be defined in this model, $f_{eH}$ still satisfies Eq.~(\ref{eq:feExperimentalConstraint}).
 
 \section{Tensor-to-scalar power spectra ratios in single-field models \label{sec:r}}
 It is interesting to observe that the values of the tensor-to-scalar ratio $r \ll 1$ in global supersymmetry Fig.~(\ref{fig:supersymmetry}) and supergravity Fig.~(\ref{fig:supergravity}) models we considered, but is close to experimental limit $r \approx 0.1$ for some points in the DBI model Fig.~(\ref{fig:DBI}).


### PR DESCRIPTION
## Changes
* Closes #36.
* Adds a note about DBI simulations to the main text.

## Tests and commands
* Build the paper with `./build.sh` too get:
<img width="697" alt="Screen Shot 2019-05-31 at 00 01 37" src="https://user-images.githubusercontent.com/1479325/58682711-44aae080-8337-11e9-99a4-9aede9fafb0d.png">

[coherent-enhancement.pdf](https://github.com/maxitg/coherent-enhancement/files/3239760/coherent-enhancement.pdf)