### PR TITLE
Explicit horizon exit clarification to `fig:density`

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -788,7 +788,8 @@ where we used the definition of the slow-roll parameter $\epsilon$, see Eq.~(\re
     Evolution of density as a function of the number of e-foldings until the end of inflation for global supersymmetry (top left panel), supergravity (top right panel) and DBI (bottom panel) models.
     Examples with the largest values of the ratio $r$ of tensor-to-scalar power spectra are chosen in each case.
     Here $\rho_0$ is the density at the beginning of the simulation, and the number of e-foldings is shown negative for convenience as $N - N_\text{total} < 0$.
-    Note the change in density is more uniform in the case of DBI, which explains higher values of $r$.
+    Horizon exit occurs at $-60 < N - N_\text{total} < -50$.
+    Note at that point, the density in global supersymmetry and supergravity models changes much slower than in DBI, which explains smaller values of $r$ in these models.
   } \label{fig:density}
 \end{figure}
 


### PR DESCRIPTION
## Changes
* Closes #39.
* Adds a note clarifying that horizon exit occurs between -60 and -50 e-foldings in `fig:density`.

## Tests and commands
* Build the paper `./build.sh` to get
<img width="689" alt="Screen Shot 2019-05-31 at 00 11 23" src="https://user-images.githubusercontent.com/1479325/58683045-a15acb00-8338-11e9-942f-a3e85a674ed2.png">

[coherent-enhancement.pdf](https://github.com/maxitg/coherent-enhancement/files/3239772/coherent-enhancement.pdf)