### PR TITLE
SlowRollEpsilon equation in terms of density

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -800,7 +800,10 @@ which is what we see in Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}).
 Note also $\Delta\phi$ is larger in the supergravity model, which is consistent with it also producing larger values of $r$.
 The density in that case stays nearly constant at horizon exit since
 \begin{equation}
-  \epsilon \approx \epsilon_H \propto \dot H \propto \dot\rho\,,
+  \epsilon \approx \epsilon_H
+           = - \frac{\dot H}{H^2}
+           = - \frac{8 \sqrt{3} \dot\rho M_\text{P}}{\rho^{3 / 2}}
+           \propto \dot\rho\,,
 \end{equation}
 which can be seen in the top panels of Fig.~(\ref{fig:density}).
 


### PR DESCRIPTION
## Changes
* Closes #38.
* Expands Eq.(72) such that epsilon is now explicitly expressed in terms of density:
<img width="732" alt="Screen Shot 2019-05-31 at 00 33 51" src="https://user-images.githubusercontent.com/1479325/58683870-c43aae80-833b-11e9-82ed-e3ce3cb08dde.png">

## Tests and commands
* Build with `./build.sh` to get [coherent-enhancement.pdf](https://github.com/maxitg/coherent-enhancement/files/3239831/coherent-enhancement.pdf).