### PR TITLE
Live URLs in bibliography

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -1003,13 +1003,6 @@ This research was supported in part by the NSF Grant PHY-1620575.
   Nucl.\ Phys.\ B {\bf 227}, 121 (1983).
   \href{https://dx.doi.org/10.1016/0550-3213(83)90145-1}{doi:10.1016/0550-3213(83)90145-1}
 
-\bibitem{Kachru:2003aw}
-  S.~Kachru, R.~Kallosh, A.~D.~Linde and S.~P.~Trivedi,
-  %``De Sitter vacua in string theory,''
-  Phys.\ Rev.\ D {\bf 68}, 046005 (2003)
-  \href{https://dx.doi.org/10.1103/PhysRevD.68.046005}{doi:10.1103/PhysRevD.68.046005}
-  \href{https://arxiv.org/abs/hep-th/0301240}{[hep-th/0301240]}.
-
 \bibitem{Balasubramanian:2005zx}
   V.~Balasubramanian, P.~Berglund, J.~P.~Conlon and F.~Quevedo,
   %``Systematics of moduli stabilisation in Calabi-Yau flux compactifications,''
@@ -1115,13 +1108,6 @@ This research was supported in part by the NSF Grant PHY-1620575.
   \href{https://dx.doi.org/10.1103/PhysRevLett.113.051601}{doi:10.1103/PhysRevLett.113.051601}
   \href{https://arxiv.org/abs/1402.2287}{[arXiv:1402.2287 [hep-ph]]}.
 
-\bibitem{Banks:2003sx}
-  T.~Banks, M.~Dine, P.~J.~Fox and E.~Gorbatov,
-  %``On the possibility of large axion decay constants,''
-  JCAP {\bf 0306}, 001 (2003)
-  \href{https://dx.doi.org/10.1088/1475-7516/2003/06/001}{doi:10.1088/1475-7516/2003/06/001}
-  \href{https://arxiv.org/abs/hep-th/0303252}{[hep-th/0303252]}.
-
 \bibitem{BlancoPillado:2004ns}
   J.~J.~Blanco-Pillado, C.~P.~Burgess, J.~M.~Cline, C.~Escoda, M.~Gomez-Reino, R.~Kallosh, A.~D.~Linde and F.~Quevedo,
   %``Racetrack inflation,''
@@ -1142,13 +1128,6 @@ This research was supported in part by the NSF Grant PHY-1620575.
   JHEP {\bf 0603}, 035 (2006)
   \href{https://dx.doi.org/10.1088/1126-6708/2006/03/035}{doi:10.1088/1126-6708/2006/03/035}
   \href{https://arxiv.org/abs/hep-th/0512135}{[hep-th/0512135]}.
-
-\bibitem{BlancoPillado:2006he}
-  J.~J.~Blanco-Pillado, C.~P.~Burgess, J.~M.~Cline, C.~Escoda, M.~Gomez-Reino, R.~Kallosh, A.~D.~Linde and F.~Quevedo,
-  %``Inflating in a better racetrack,''
-  JHEP {\bf 0609}, 002 (2006)
-  \href{https://dx.doi.org/10.1088/1126-6708/2006/09/002}{doi:10.1088/1126-6708/2006/09/002}
-  \href{https://arxiv.org/abs/hep-th/0603129}{[hep-th/0603129]}.
 
 \bibitem{Brown:2015iha}
   J.~Brown, W.~Cottrell, G.~Shiu and P.~Soler,

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -985,6 +985,34 @@ This research was supported in part by the NSF Grant PHY-1620575.
   \href{https://dx.doi.org/10.1103/PhysRevD.52.912}{doi:10.1103/PhysRevD.52.912}
   \href{https://arxiv.org/abs/hep-th/9502069}{[hep-th/9502069]}.
 
+\bibitem{BlancoPillado:2004ns}
+  J.~J.~Blanco-Pillado, C.~P.~Burgess, J.~M.~Cline, C.~Escoda, M.~Gomez-Reino, R.~Kallosh, A.~D.~Linde and F.~Quevedo,
+  %``Racetrack inflation,''
+  JHEP {\bf 0411}, 063 (2004)
+  \href{https://dx.doi.org/10.1088/1126-6708/2004/11/063}{doi:10.1088/1126-6708/2004/11/063}
+  \href{https://arxiv.org/abs/hep-th/0406230}{[hep-th/0406230]}.
+
+\bibitem{Lalak:2005hr}
+  Z.~Lalak, G.~G.~Ross and S.~Sarkar,
+  %``Racetrack inflation and assisted moduli stabilisation,''
+  Nucl.\ Phys.\ B {\bf 766}, 1 (2007)
+  \href{https://dx.doi.org/10.1016/j.nuclphysb.2006.06.041}{doi:10.1016/j.nuclphysb.2006.06.041}
+  \href{https://arxiv.org/abs/hep-th/0503178}{[hep-th/0503178]}.
+
+\bibitem{Greene:2005rn}
+  B.~Greene and A.~Weltman,
+  %``An Effect of alpha' corrections on racetrack inflation,''
+  JHEP {\bf 0603}, 035 (2006)
+  \href{https://dx.doi.org/10.1088/1126-6708/2006/03/035}{doi:10.1088/1126-6708/2006/03/035}
+  \href{https://arxiv.org/abs/hep-th/0512135}{[hep-th/0512135]}.
+
+\bibitem{Nath:2018xxe}
+  P.~Nath and M.~Piskunov,
+  %``Supersymmetric Dirac-Born-Infeld Axionic Inflation and Non-Gaussianity,''
+  JHEP {\bf 1902}, 034 (2019)
+  \href{https://dx.doi.org/10.1007/JHEP02(2019)034}{doi:10.1007/JHEP02(2019)034}
+  \href{https://arxiv.org/abs/1807.02549}{[arXiv:1807.02549 [hep-ph]]}.
+
 \bibitem{Chamseddine:1982jx}
   A.~H.~Chamseddine, R.~L.~Arnowitt and P.~Nath,
   %``Locally Supersymmetric Grand Unification,''
@@ -1080,13 +1108,6 @@ This research was supported in part by the NSF Grant PHY-1620575.
   \href{https://dx.doi.org/10.1007/JHEP01(2017)121}{doi:10.1007/JHEP01(2017)121}
   \href{https://arxiv.org/abs/1611.08426}{[arXiv:1611.08426 [hep-th]]}.
 
-\bibitem{Nath:2018xxe}
-  P.~Nath and M.~Piskunov,
-  %``Supersymmetric Dirac-Born-Infeld Axionic Inflation and Non-Gaussianity,''
-  JHEP {\bf 1902}, 034 (2019)
-  \href{https://dx.doi.org/10.1007/JHEP02(2019)034}{doi:10.1007/JHEP02(2019)034}
-  \href{https://arxiv.org/abs/1807.02549}{[arXiv:1807.02549 [hep-ph]]}.
-
 \bibitem{Lyth:1996im}
   D.~H.~Lyth,
   %``What would we learn by detecting a gravitational wave signal in the cosmic microwave background anisotropy?,''
@@ -1107,27 +1128,6 @@ This research was supported in part by the NSF Grant PHY-1620575.
   Phys.\ Rev.\ Lett.\  {\bf 113}, 051601 (2014)
   \href{https://dx.doi.org/10.1103/PhysRevLett.113.051601}{doi:10.1103/PhysRevLett.113.051601}
   \href{https://arxiv.org/abs/1402.2287}{[arXiv:1402.2287 [hep-ph]]}.
-
-\bibitem{BlancoPillado:2004ns}
-  J.~J.~Blanco-Pillado, C.~P.~Burgess, J.~M.~Cline, C.~Escoda, M.~Gomez-Reino, R.~Kallosh, A.~D.~Linde and F.~Quevedo,
-  %``Racetrack inflation,''
-  JHEP {\bf 0411}, 063 (2004)
-  \href{https://dx.doi.org/10.1088/1126-6708/2004/11/063}{doi:10.1088/1126-6708/2004/11/063}
-  \href{https://arxiv.org/abs/hep-th/0406230}{[hep-th/0406230]}.
-
-\bibitem{Lalak:2005hr}
-  Z.~Lalak, G.~G.~Ross and S.~Sarkar,
-  %``Racetrack inflation and assisted moduli stabilisation,''
-  Nucl.\ Phys.\ B {\bf 766}, 1 (2007)
-  \href{https://dx.doi.org/10.1016/j.nuclphysb.2006.06.041}{doi:10.1016/j.nuclphysb.2006.06.041}
-  \href{https://arxiv.org/abs/hep-th/0503178}{[hep-th/0503178]}.
-
-\bibitem{Greene:2005rn}
-  B.~Greene and A.~Weltman,
-  %``An Effect of alpha' corrections on racetrack inflation,''
-  JHEP {\bf 0603}, 035 (2006)
-  \href{https://dx.doi.org/10.1088/1126-6708/2006/03/035}{doi:10.1088/1126-6708/2006/03/035}
-  \href{https://arxiv.org/abs/hep-th/0512135}{[hep-th/0512135]}.
 
 \bibitem{Brown:2015iha}
   J.~Brown, W.~Cottrell, G.~Shiu and P.~Soler,

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -878,24 +878,24 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``The Effective Field Theory of Inflation,''
   JHEP {\bf 0803}, 014 (2008)
   \href{https://dx.doi.org/10.1088/1126-6708/2008/03/014}{doi:10.1088/1126-6708/2008/03/014}
-  [arXiv:0709.0293 [hep-th]].
+  \href{https://arxiv.org/abs/0709.0293}{[arXiv:0709.0293 [hep-th]]}.
 
 \bibitem{Akrami:2018vks}
   Y.~Akrami {\it et al.} [Planck Collaboration],
   %``Planck 2018 results. I. Overview and the cosmological legacy of Planck,''
-  arXiv:1807.06205 [astro-ph.CO].
+  \href{https://arxiv.org/abs/1807.06205}{arXiv:1807.06205 [astro-ph.CO]}.
 
 \bibitem{Akrami:2018odb}
   Y.~Akrami {\it et al.} [Planck Collaboration],
   %``Planck 2018 results. X. Constraints on inflation,''
-  arXiv:1807.06211 [astro-ph.CO].
+  \href{https://arxiv.org/abs/1807.06211}{arXiv:1807.06211 [astro-ph.CO]}.
 
 \bibitem{Array:2015xqh}
   P.~A.~R.~Ade {\it et al.} [BICEP2 and Keck Array Collaborations],
   %``Improved Constraints on Cosmology and Foregrounds from BICEP2 and Keck Array Cosmic Microwave Background Data with Inclusion of 95 GHz Band,''
   Phys.\ Rev.\ Lett.\  {\bf 116}, 031302 (2016)
   \href{https://dx.doi.org/10.1103/PhysRevLett.116.031302}{doi:10.1103/PhysRevLett.116.031302}
-  [arXiv:1510.09217 [astro-ph.CO]].
+  \href{https://arxiv.org/abs/1510.09217}{[arXiv:1510.09217 [astro-ph.CO]]}.
 
 \bibitem{Freese:1990rb}
   K.~Freese, J.~A.~Frieman and A.~V.~Olinto,
@@ -936,14 +936,14 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Aligned Natural Inflation in String Theory,''
   Phys.\ Rev.\ D {\bf 90}, 023501 (2014)
   \href{https://dx.doi.org/10.1103/PhysRevD.90.023501}{doi:10.1103/PhysRevD.90.023501}
-  [arXiv:1404.7852 [hep-th]].
+  \href{https://arxiv.org/abs/1404.7852}{[arXiv:1404.7852 [hep-th]]}.
 
 \bibitem{Nath:2017ihp}
   P.~Nath and M.~Piskunov,
   %``Evidence for Inflation in an Axion Landscape,''
   JHEP {\bf 1803}, 121 (2018)
   \href{https://dx.doi.org/10.1007/JHEP03(2018)121}{doi:10.1007/JHEP03(2018)121}
-  [arXiv:1712.01357 [hep-ph]].
+  \href{https://arxiv.org/abs/1712.01357}{[arXiv:1712.01357 [hep-ph]]}.
 
 \bibitem{Nath:2016qzm}
   P.~Nath,
@@ -969,14 +969,14 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Towards Natural Inflation in String Theory,''
   Phys.\ Rev.\ D {\bf 92}, no. 2, 023515 (2015)
   \href{https://dx.doi.org/10.1103/PhysRevD.92.023515}{doi:10.1103/PhysRevD.92.023515}
-  [arXiv:1407.2562 [hep-th]].
+  \href{https://arxiv.org/abs/1407.2562}{[arXiv:1407.2562 [hep-th]]}.
 
 \bibitem{Gao:2014uha}
   X.~Gao, T.~Li and P.~Shukla,
   %``Combining Universal and Odd RR Axions for Aligned Natural Inflation,''
   JCAP {\bf 1410}, 048 (2014)
   \href{https://dx.doi.org/10.1088/1475-7516/2014/10/048}{doi:10.1088/1475-7516/2014/10/048}
-  [arXiv:1406.0341 [hep-th]].
+  \href{https://arxiv.org/abs/1406.0341}{[arXiv:1406.0341 [hep-th]]}.
 
 \bibitem{Kallosh:1995hi}
   R.~Kallosh, A.~D.~Linde, D.~A.~Linde and L.~Susskind,
@@ -1022,28 +1022,28 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Supersymmetric P(X,$\phi$) and the Ghost Condensate,''
   Phys.\ Rev.\ D {\bf 83}, 125031 (2011)
   \href{https://dx.doi.org/10.1103/PhysRevD.83.125031}{doi:10.1103/PhysRevD.83.125031}
-  [arXiv:1012.3748 [hep-th]].
+  \href{https://arxiv.org/abs/1012.3748}{[arXiv:1012.3748 [hep-th]]}.
 
 \bibitem{Khoury:2011da}
   J.~Khoury, J.~L.~Lehners and B.~A.~Ovrut,
   %``Supersymmetric Galileons,''
   Phys.\ Rev.\ D {\bf 84}, 043521 (2011)
   \href{https://dx.doi.org/10.1103/PhysRevD.84.043521}{doi:10.1103/PhysRevD.84.043521}
-  [arXiv:1103.0003 [hep-th]].
+  \href{https://arxiv.org/abs/1103.0003}{[arXiv:1103.0003 [hep-th]]}.
 
 \bibitem{Baumann:2011nk}
   D.~Baumann and D.~Green,
   %``Signatures of Supersymmetry from the Early Universe,''
   Phys.\ Rev.\ D {\bf 85}, 103520 (2012)
   \href{https://dx.doi.org/10.1103/PhysRevD.85.103520}{doi:10.1103/PhysRevD.85.103520}
-  [arXiv:1109.0292 [hep-th]].
+  \href{https://arxiv.org/abs/1109.0292}{[arXiv:1109.0292 [hep-th]]}.
 
 \bibitem{Baumann:2011nm}
   D.~Baumann and D.~Green,
   %``Supergravity for Effective Theories,''
   JHEP {\bf 1203}, 001 (2012)
   \href{https://dx.doi.org/10.1007/JHEP03(2012)001}{doi:10.1007/JHEP03(2012)001}
-  [arXiv:1109.0293 [hep-th]].
+  \href{https://arxiv.org/abs/1109.0293}{[arXiv:1109.0293 [hep-th]]}.
 
 \bibitem{Rocek:1997hi}
   M.~Rocek and A.~A.~Tseytlin,
@@ -1064,35 +1064,35 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Deformation of super Yang-Mills theories in R-R 3-form background,''
   JHEP {\bf 0707}, 068 (2007)
   \href{https://dx.doi.org/10.1088/1126-6708/2007/07/068}{doi:10.1088/1126-6708/2007/07/068}
-  [arXiv:0705.3532 [hep-th]].
+  \href{https://arxiv.org/abs/0705.3532}{[arXiv:0705.3532 [hep-th]]}.
 
 \bibitem{Billo:2008sp}
   M.~Billo, L.~Ferro, M.~Frau, F.~Fucito, A.~Lerda and J.~F.~Morales,
   %``Flux interactions on D-branes and instantons,''
   JHEP {\bf 0810}, 112 (2008)
   \href{https://dx.doi.org/10.1088/1126-6708/2008/10/112}{doi:10.1088/1126-6708/2008/10/112}
-  [arXiv:0807.1666 [hep-th]].
+  \href{https://arxiv.org/abs/0807.1666}{[arXiv:0807.1666 [hep-th]]}.
 
 \bibitem{Sasaki:2012ka}
   S.~Sasaki, M.~Yamaguchi and D.~Yokoyama,
   %``Supersymmetric DBI inflation,''
   Phys.\ Lett.\ B {\bf 718}, 1 (2012)
   \href{https://dx.doi.org/10.1016/j.physletb.2012.10.006}{doi:10.1016/j.physletb.2012.10.006}
-  [arXiv:1205.1353 [hep-th]].
+  \href{https://arxiv.org/abs/1205.1353}{[arXiv:1205.1353 [hep-th]]}.
 
 \bibitem{Aoki:2016tod}
   S.~Aoki and Y.~Yamada,
   %``More on DBI action in 4D $ \mathcal{N} $ = 1 supergravity,''
   JHEP {\bf 1701}, 121 (2017)
   \href{https://dx.doi.org/10.1007/JHEP01(2017)121}{doi:10.1007/JHEP01(2017)121}
-  [arXiv:1611.08426 [hep-th]].
+  \href{https://arxiv.org/abs/1611.08426}{[arXiv:1611.08426 [hep-th]]}.
 
 \bibitem{Nath:2018xxe}
   P.~Nath and M.~Piskunov,
   %``Supersymmetric Dirac-Born-Infeld Axionic Inflation and Non-Gaussianity,''
   JHEP {\bf 1902}, 034 (2019)
   \href{https://dx.doi.org/10.1007/JHEP02(2019)034}{doi:10.1007/JHEP02(2019)034}
-  [arXiv:1807.02549 [hep-ph]].
+  \href{https://arxiv.org/abs/1807.02549}{[arXiv:1807.02549 [hep-ph]]}.
 
 \bibitem{Lyth:1996im}
   D.~H.~Lyth,
@@ -1113,7 +1113,7 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Naturalness and the Weak Gravity Conjecture,''
   Phys.\ Rev.\ Lett.\  {\bf 113}, 051601 (2014)
   \href{https://dx.doi.org/10.1103/PhysRevLett.113.051601}{doi:10.1103/PhysRevLett.113.051601}
-  [arXiv:1402.2287 [hep-ph]].
+  \href{https://arxiv.org/abs/1402.2287}{[arXiv:1402.2287 [hep-ph]]}.
 
 \bibitem{Banks:2003sx}
   T.~Banks, M.~Dine, P.~J.~Fox and E.~Gorbatov,
@@ -1155,70 +1155,70 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Fencing in the Swampland: Quantum Gravity Constraints on Large Field Inflation,''
   JHEP {\bf 1510}, 023 (2015)
   \href{https://dx.doi.org/10.1007/JHEP10(2015)023}{doi:10.1007/JHEP10(2015)023}
-  [arXiv:1503.04783 [hep-th]].
+  \href{https://arxiv.org/abs/1503.04783}{[arXiv:1503.04783 [hep-th]]}.
 
 \bibitem{Heidenreich:2015wga}
   B.~Heidenreich, M.~Reece and T.~Rudelius,
   %``Weak Gravity Strongly Constrains Large-Field Axion Inflation,''
   JHEP {\bf 1512}, 108 (2015)
   \href{https://dx.doi.org/10.1007/JHEP12(2015)108}{doi:10.1007/JHEP12(2015)108}
-  [arXiv:1506.03447 [hep-th]].
+  \href{https://arxiv.org/abs/1506.03447}{[arXiv:1506.03447 [hep-th]]}.
 
 \bibitem{Rudelius:2015xta}
   T.~Rudelius,
   %``Constraints on Axion Inflation from the Weak Gravity Conjecture,''
   JCAP {\bf 1509}, no. 09, 020 (2015)
   \href{https://dx.doi.org/10.1088/1475-7516/2015/09/020}{doi:10.1088/1475-7516/2015/09/020}
-  [arXiv:1503.00795 [hep-th]].
+  \href{https://arxiv.org/abs/1503.00795}{[arXiv:1503.00795 [hep-th]]}.
 
 \bibitem{Rudelius:2014wla}
   T.~Rudelius,
   %``On the Possibility of Large Axion Moduli Spaces,''
   JCAP {\bf 1504}, no. 04, 049 (2015)
   \href{https://dx.doi.org/10.1088/1475-7516/2015/04/049}{doi:10.1088/1475-7516/2015/04/049}
-  [arXiv:1409.5793 [hep-th]].
+  \href{https://arxiv.org/abs/1409.5793}{[arXiv:1409.5793 [hep-th]]}.
 
 \bibitem{Bachlechner:2014gfa}
   T.~C.~Bachlechner, C.~Long and L.~McAllister,
   %``Planckian Axions in String Theory,''
   JHEP {\bf 1512}, 042 (2015)
   \href{https://dx.doi.org/10.1007/JHEP12(2015)042}{doi:10.1007/JHEP12(2015)042}
-  [arXiv:1412.1093 [hep-th]].
+  \href{https://arxiv.org/abs/1412.1093}{[arXiv:1412.1093 [hep-th]]}.
 
 \bibitem{Choi:2014rja}
   K.~Choi, H.~Kim and S.~Yun,
   %``Natural inflation with multiple sub-Planckian axions,''
   Phys.\ Rev.\ D {\bf 90}, 023545 (2014)
   \href{https://dx.doi.org/10.1103/PhysRevD.90.023545}{doi:10.1103/PhysRevD.90.023545}
-  [arXiv:1404.6209 [hep-th]].
+  \href{https://arxiv.org/abs/1404.6209}{[arXiv:1404.6209 [hep-th]]}.
 
 \bibitem{Hebecker:2015rya}
   A.~Hebecker, P.~Mangat, F.~Rompineve and L.~T.~Witkowski,
   %``Winding out of the Swamp: Evading the Weak Gravity Conjecture with F-term Winding Inflation?,''
   Phys.\ Lett.\ B {\bf 748}, 455 (2015)
   \href{https://dx.doi.org/10.1016/j.physletb.2015.07.026}{doi:10.1016/j.physletb.2015.07.026}
-  [arXiv:1503.07912 [hep-th]].
+  \href{https://arxiv.org/abs/1503.07912}{[arXiv:1503.07912 [hep-th]]}.
 
 \bibitem{Conlon:2016aea}
   J.~P.~Conlon and S.~Krippendorf,
   %``Axion decay constants away from the lamppost,''
   JHEP {\bf 1604}, 085 (2016)
   \href{https://dx.doi.org/10.1007/JHEP04(2016)085}{doi:10.1007/JHEP04(2016)085}
-  [arXiv:1601.00647 [hep-th]].
+  \href{https://arxiv.org/abs/1601.00647}{[arXiv:1601.00647 [hep-th]]}.
 
 \bibitem{Montero:2015ofa}
   M.~Montero, A.~M.~Uranga and I.~Valenzuela,
   %``Transplanckian axions!?,''
   JHEP {\bf 1508}, 032 (2015)
   \href{https://dx.doi.org/10.1007/JHEP08(2015)032}{doi:10.1007/JHEP08(2015)032}
-  [arXiv:1503.03886 [hep-th]].
+  \href{https://arxiv.org/abs/1503.03886}{[arXiv:1503.03886 [hep-th]]}.
 
 \bibitem{Junghans:2015hba}
   D.~Junghans,
   %``Large-Field Inflation with Multiple Axions and the Weak Gravity Conjecture,''
   JHEP {\bf 1602}, 128 (2016)
   \href{https://dx.doi.org/10.1007/JHEP02(2016)128}{doi:10.1007/JHEP02(2016)128}
-  [arXiv:1504.03566 [hep-th]].
+  \href{https://arxiv.org/abs/1504.03566}{[arXiv:1504.03566 [hep-th]]}.
 
 \end{thebibliography}
 

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -808,7 +808,7 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``The Inflationary Universe: A Possible Solution to the Horizon and Flatness Problems,''
   Phys.\ Rev.\ D {\bf 23}, 347 (1981)
   [Adv.\ Ser.\ Astrophys.\ Cosmol.\  {\bf 3}, 139 (1987)].
-  doi:10.1103/PhysRevD.23.347
+  \href{https://dx.doi.org/10.1103/PhysRevD.23.347}{doi:10.1103/PhysRevD.23.347}
 
 \bibitem{Starobinsky:1980te}
   A.~A.~Starobinsky,
@@ -816,21 +816,21 @@ This research was supported in part by the NSF Grant PHY-1620575.
   Phys.\ Lett.\ B {\bf 91}, 99 (1980)
   [Phys.\ Lett.\  {\bf 91B}, 99 (1980)]
   [Adv.\ Ser.\ Astrophys.\ Cosmol.\  {\bf 3}, 130 (1987)].
-  doi:10.1016/0370-2693(80)90670-X
+  \href{https://dx.doi.org/10.1016/0370-2693(80)90670-X}{doi:10.1016/0370-2693(80)90670-X}
 
 \bibitem{Linde:1981mu}
   A.~D.~Linde,
   %``A New Inflationary Universe Scenario: A Possible Solution of the Horizon, Flatness, Homogeneity, Isotropy and Primordial Monopole Problems,''
   Phys.\ Lett.\  {\bf 108B}, 389 (1982)
   [Adv.\ Ser.\ Astrophys.\ Cosmol.\  {\bf 3}, 149 (1987)].
-  doi:10.1016/0370-2693(82)91219-9
+  \href{https://dx.doi.org/10.1016/0370-2693(82)91219-9}{doi:10.1016/0370-2693(82)91219-9}
 
 \bibitem{Albrecht:1982wi}
   A.~Albrecht and P.~J.~Steinhardt,
   %``Cosmology for Grand Unified Theories with Radiatively Induced Symmetry Breaking,''
   Phys.\ Rev.\ Lett.\  {\bf 48}, 1220 (1982)
   [Adv.\ Ser.\ Astrophys.\ Cosmol.\  {\bf 3}, 158 (1987)].
-  doi:10.1103/PhysRevLett.48.1220
+  \href{https://dx.doi.org/10.1103/PhysRevLett.48.1220}{doi:10.1103/PhysRevLett.48.1220}
 
 \bibitem{Sato:1980yn}
   K.~Sato,
@@ -841,7 +841,7 @@ This research was supported in part by the NSF Grant PHY-1620575.
   A.~D.~Linde,
   %``Chaotic Inflation,''
   Phys.\ Lett.\  {\bf 129B}, 177 (1983).
-  doi:10.1016/0370-2693(83)90837-7
+  \href{https://dx.doi.org/10.1016/0370-2693(83)90837-7}{doi:10.1016/0370-2693(83)90837-7}
 
 \bibitem{Mukhanov:1981xt}
   V.~F.~Mukhanov and G.~V.~Chibisov,
@@ -853,31 +853,31 @@ This research was supported in part by the NSF Grant PHY-1620575.
   S.~W.~Hawking,
   %``The Development of Irregularities in a Single Bubble Inflationary Universe,''
   Phys.\ Lett.\  {\bf 115B}, 295 (1982).
-  doi:10.1016/0370-2693(82)90373-2
+  \href{https://dx.doi.org/10.1016/0370-2693(82)90373-2}{doi:10.1016/0370-2693(82)90373-2}
 
 \bibitem{Starobinsky:1982ee}
   A.~A.~Starobinsky,
   %``Dynamics of Phase Transition in the New Inflationary Universe Scenario and Generation of Perturbations,''
   Phys.\ Lett.\  {\bf 117B}, 175 (1982).
-  doi:10.1016/0370-2693(82)90541-X
+  \href{https://dx.doi.org/10.1016/0370-2693(82)90541-X}{doi:10.1016/0370-2693(82)90541-X}
 
 \bibitem{Guth:1982ec}
   A.~H.~Guth and S.~Y.~Pi,
   %``Fluctuations in the New Inflationary Universe,''
   Phys.\ Rev.\ Lett.\  {\bf 49}, 1110 (1982).
-  doi:10.1103/PhysRevLett.49.1110
+  \href{https://dx.doi.org/10.1103/PhysRevLett.49.1110}{doi:10.1103/PhysRevLett.49.1110}
 
 \bibitem{Bardeen:1983qw}
   J.~M.~Bardeen, P.~J.~Steinhardt and M.~S.~Turner,
   %``Spontaneous Creation of Almost Scale - Free Density Perturbations in an Inflationary Universe,''
   Phys.\ Rev.\ D {\bf 28}, 679 (1983).
-  doi:10.1103/PhysRevD.28.679
+  \href{https://dx.doi.org/10.1103/PhysRevD.28.679}{doi:10.1103/PhysRevD.28.679}
 
 \bibitem{Cheung:2007st}
   C.~Cheung, P.~Creminelli, A.~L.~Fitzpatrick, J.~Kaplan and L.~Senatore,
   %``The Effective Field Theory of Inflation,''
   JHEP {\bf 0803}, 014 (2008)
-  doi:10.1088/1126-6708/2008/03/014
+  \href{https://dx.doi.org/10.1088/1126-6708/2008/03/014}{doi:10.1088/1126-6708/2008/03/014}
   [arXiv:0709.0293 [hep-th]].
 
 \bibitem{Akrami:2018vks}
@@ -894,330 +894,330 @@ This research was supported in part by the NSF Grant PHY-1620575.
   P.~A.~R.~Ade {\it et al.} [BICEP2 and Keck Array Collaborations],
   %``Improved Constraints on Cosmology and Foregrounds from BICEP2 and Keck Array Cosmic Microwave Background Data with Inclusion of 95 GHz Band,''
   Phys.\ Rev.\ Lett.\  {\bf 116}, 031302 (2016)
-  doi:10.1103/PhysRevLett.116.031302
+  \href{https://dx.doi.org/10.1103/PhysRevLett.116.031302}{doi:10.1103/PhysRevLett.116.031302}
   [arXiv:1510.09217 [astro-ph.CO]].
 
 \bibitem{Freese:1990rb}
   K.~Freese, J.~A.~Frieman and A.~V.~Olinto,
   %``Natural inflation with pseudo - Nambu-Goldstone bosons,''
   Phys.\ Rev.\ Lett.\  {\bf 65}, 3233 (1990).
-  doi:10.1103/PhysRevLett.65.3233
+  \href{https://dx.doi.org/10.1103/PhysRevLett.65.3233}{doi:10.1103/PhysRevLett.65.3233}
 
 \bibitem{Adams:1992bn}
   F.~C.~Adams, J.~R.~Bond, K.~Freese, J.~A.~Frieman and A.~V.~Olinto,
   %``Natural inflation: Particle physics models, power law spectra for large scale structure, and constraints from COBE,''
   Phys.\ Rev.\ D {\bf 47}, 426 (1993)
-  doi:10.1103/PhysRevD.47.426
+  \href{https://dx.doi.org/10.1103/PhysRevD.47.426}{doi:10.1103/PhysRevD.47.426}
   [hep-ph/9207245].
 
 \bibitem{Banks:2003sx}
   T.~Banks, M.~Dine, P.~J.~Fox and E.~Gorbatov,
   %``On the possibility of large axion decay constants,''
   JCAP {\bf 0306}, 001 (2003)
-  doi:10.1088/1475-7516/2003/06/001
+  \href{https://dx.doi.org/10.1088/1475-7516/2003/06/001}{doi:10.1088/1475-7516/2003/06/001}
   [hep-th/0303252].
 
 \bibitem{Svrcek:2006yi}
   P.~Svrcek and E.~Witten,
   %``Axions In String Theory,''
   JHEP {\bf 0606}, 051 (2006)
-  doi:10.1088/1126-6708/2006/06/051
+  \href{https://dx.doi.org/10.1088/1126-6708/2006/06/051}{doi:10.1088/1126-6708/2006/06/051}
   [hep-th/0605206].
 
 \bibitem{Kim:2004rp}
   J.~E.~Kim, H.~P.~Nilles and M.~Peloso,
   %``Completing natural inflation,''
   JCAP {\bf 0501}, 005 (2005)
-  doi:10.1088/1475-7516/2005/01/005
+  \href{https://dx.doi.org/10.1088/1475-7516/2005/01/005}{doi:10.1088/1475-7516/2005/01/005}
   [hep-ph/0409138].
 
 \bibitem{Long:2014dta}
   C.~Long, L.~McAllister and P.~McGuirk,
   %``Aligned Natural Inflation in String Theory,''
   Phys.\ Rev.\ D {\bf 90}, 023501 (2014)
-  doi:10.1103/PhysRevD.90.023501
+  \href{https://dx.doi.org/10.1103/PhysRevD.90.023501}{doi:10.1103/PhysRevD.90.023501}
   [arXiv:1404.7852 [hep-th]].
 
 \bibitem{Nath:2017ihp}
   P.~Nath and M.~Piskunov,
   %``Evidence for Inflation in an Axion Landscape,''
   JHEP {\bf 1803}, 121 (2018)
-  doi:10.1007/JHEP03(2018)121
+  \href{https://dx.doi.org/10.1007/JHEP03(2018)121}{doi:10.1007/JHEP03(2018)121}
   [arXiv:1712.01357 [hep-ph]].
 
 \bibitem{Nath:2016qzm}
   P.~Nath,
   %``Supersymmetry, Supergravity, and Unification,''
-  doi:10.1017/9781139048118
+  \href{https://dx.doi.org/10.1017/9781139048118}{doi:10.1017/9781139048118}
 
 \bibitem{BlancoPillado:2006he}
   J.~J.~Blanco-Pillado, C.~P.~Burgess, J.~M.~Cline, C.~Escoda, M.~Gomez-Reino, R.~Kallosh, A.~D.~Linde and F.~Quevedo,
   %``Inflating in a better racetrack,''
   JHEP {\bf 0609}, 002 (2006)
-  doi:10.1088/1126-6708/2006/09/002
+  \href{https://dx.doi.org/10.1088/1126-6708/2006/09/002}{doi:10.1088/1126-6708/2006/09/002}
   [hep-th/0603129].
 
 \bibitem{Conlon:2005jm}
   J.~P.~Conlon and F.~Quevedo,
   %``Kahler moduli inflation,''
   JHEP {\bf 0601}, 146 (2006)
-  doi:10.1088/1126-6708/2006/01/146
+  \href{https://dx.doi.org/10.1088/1126-6708/2006/01/146}{doi:10.1088/1126-6708/2006/01/146}
   [hep-th/0509012].
 
 \bibitem{Ben-Dayan:2014lca}
   I.~Ben-Dayan, F.~G.~Pedro and A.~Westphal,
   %``Towards Natural Inflation in String Theory,''
   Phys.\ Rev.\ D {\bf 92}, no. 2, 023515 (2015)
-  doi:10.1103/PhysRevD.92.023515
+  \href{https://dx.doi.org/10.1103/PhysRevD.92.023515}{doi:10.1103/PhysRevD.92.023515}
   [arXiv:1407.2562 [hep-th]].
 
 \bibitem{Gao:2014uha}
   X.~Gao, T.~Li and P.~Shukla,
   %``Combining Universal and Odd RR Axions for Aligned Natural Inflation,''
   JCAP {\bf 1410}, 048 (2014)
-  doi:10.1088/1475-7516/2014/10/048
+  \href{https://dx.doi.org/10.1088/1475-7516/2014/10/048}{doi:10.1088/1475-7516/2014/10/048}
   [arXiv:1406.0341 [hep-th]].
 
 \bibitem{Kallosh:1995hi}
   R.~Kallosh, A.~D.~Linde, D.~A.~Linde and L.~Susskind,
   %``Gravity and global symmetries,''
   Phys.\ Rev.\ D {\bf 52}, 912 (1995)
-  doi:10.1103/PhysRevD.52.912
+  \href{https://dx.doi.org/10.1103/PhysRevD.52.912}{doi:10.1103/PhysRevD.52.912}
   [hep-th/9502069].
 
 \bibitem{Chamseddine:1982jx}
   A.~H.~Chamseddine, R.~L.~Arnowitt and P.~Nath,
   %``Locally Supersymmetric Grand Unification,''
   Phys.\ Rev.\ Lett.\  {\bf 49}, 970 (1982).
-  doi:10.1103/PhysRevLett.49.970
+  \href{https://dx.doi.org/10.1103/PhysRevLett.49.970}{doi:10.1103/PhysRevLett.49.970}
 
 \bibitem{Cremmer:1982en}
   E.~Cremmer, S.~Ferrara, L.~Girardello and A.~Van Proeyen,
   %``Yang-Mills Theories with Local Supersymmetry: Lagrangian, Transformation Laws and SuperHiggs Effect,''
   Nucl.\ Phys.\ B {\bf 212}, 413 (1983).
-  doi:10.1016/0550-3213(83)90679-X
+  \href{https://dx.doi.org/10.1016/0550-3213(83)90679-X}{doi:10.1016/0550-3213(83)90679-X}
 
 \bibitem{Nath:1983aw}
   P.~Nath, R.~L.~Arnowitt and A.~H.~Chamseddine,
   %``Gauge Hierarchy in Supergravity Guts,''
   Nucl.\ Phys.\ B {\bf 227}, 121 (1983).
-  doi:10.1016/0550-3213(83)90145-1
+  \href{https://dx.doi.org/10.1016/0550-3213(83)90145-1}{doi:10.1016/0550-3213(83)90145-1}
 
 \bibitem{Kachru:2003aw}
   S.~Kachru, R.~Kallosh, A.~D.~Linde and S.~P.~Trivedi,
   %``De Sitter vacua in string theory,''
   Phys.\ Rev.\ D {\bf 68}, 046005 (2003)
-  doi:10.1103/PhysRevD.68.046005
+  \href{https://dx.doi.org/10.1103/PhysRevD.68.046005}{doi:10.1103/PhysRevD.68.046005}
   [hep-th/0301240].
 
 \bibitem{Balasubramanian:2005zx}
   V.~Balasubramanian, P.~Berglund, J.~P.~Conlon and F.~Quevedo,
   %``Systematics of moduli stabilisation in Calabi-Yau flux compactifications,''
   JHEP {\bf 0503}, 007 (2005)
-  doi:10.1088/1126-6708/2005/03/007
+  \href{https://dx.doi.org/10.1088/1126-6708/2005/03/007}{doi:10.1088/1126-6708/2005/03/007}
   [hep-th/0502058].
 
 \bibitem{Khoury:2010gb}
   J.~Khoury, J.~L.~Lehners and B.~Ovrut,
   %``Supersymmetric P(X,$\phi$) and the Ghost Condensate,''
   Phys.\ Rev.\ D {\bf 83}, 125031 (2011)
-  doi:10.1103/PhysRevD.83.125031
+  \href{https://dx.doi.org/10.1103/PhysRevD.83.125031}{doi:10.1103/PhysRevD.83.125031}
   [arXiv:1012.3748 [hep-th]].
 
 \bibitem{Khoury:2011da}
   J.~Khoury, J.~L.~Lehners and B.~A.~Ovrut,
   %``Supersymmetric Galileons,''
   Phys.\ Rev.\ D {\bf 84}, 043521 (2011)
-  doi:10.1103/PhysRevD.84.043521
+  \href{https://dx.doi.org/10.1103/PhysRevD.84.043521}{doi:10.1103/PhysRevD.84.043521}
   [arXiv:1103.0003 [hep-th]].
 
 \bibitem{Baumann:2011nk}
   D.~Baumann and D.~Green,
   %``Signatures of Supersymmetry from the Early Universe,''
   Phys.\ Rev.\ D {\bf 85}, 103520 (2012)
-  doi:10.1103/PhysRevD.85.103520
+  \href{https://dx.doi.org/10.1103/PhysRevD.85.103520}{doi:10.1103/PhysRevD.85.103520}
   [arXiv:1109.0292 [hep-th]].
 
 \bibitem{Baumann:2011nm}
   D.~Baumann and D.~Green,
   %``Supergravity for Effective Theories,''
   JHEP {\bf 1203}, 001 (2012)
-  doi:10.1007/JHEP03(2012)001
+  \href{https://dx.doi.org/10.1007/JHEP03(2012)001}{doi:10.1007/JHEP03(2012)001}
   [arXiv:1109.0293 [hep-th]].
 
 \bibitem{Rocek:1997hi}
   M.~Rocek and A.~A.~Tseytlin,
   %``Partial breaking of global D = 4 supersymmetry, constrained superfields, and three-brane actions,''
   Phys.\ Rev.\ D {\bf 59}, 106001 (1999)
-  doi:10.1103/PhysRevD.59.106001
+  \href{https://dx.doi.org/10.1103/PhysRevD.59.106001}{doi:10.1103/PhysRevD.59.106001}
   [hep-th/9811232].
 
 \bibitem{Tseytlin:1999dj}
   A.~A.~Tseytlin,
   %``Born-Infeld action, supersymmetry and string theory,''
   In *Shifman, M.A. (ed.): The many faces of the superworld* 417-452
-  doi:10.1142/9789812793850\_0025
+  \href{https://dx.doi.org/10.1142/9789812793850\_0025}{doi:10.1142/9789812793850\_0025}
   [hep-th/9908105].
 
 \bibitem{Ito:2007hy}
   K.~Ito, H.~Nakajima and S.~Sasaki,
   %``Deformation of super Yang-Mills theories in R-R 3-form background,''
   JHEP {\bf 0707}, 068 (2007)
-  doi:10.1088/1126-6708/2007/07/068
+  \href{https://dx.doi.org/10.1088/1126-6708/2007/07/068}{doi:10.1088/1126-6708/2007/07/068}
   [arXiv:0705.3532 [hep-th]].
 
 \bibitem{Billo:2008sp}
   M.~Billo, L.~Ferro, M.~Frau, F.~Fucito, A.~Lerda and J.~F.~Morales,
   %``Flux interactions on D-branes and instantons,''
   JHEP {\bf 0810}, 112 (2008)
-  doi:10.1088/1126-6708/2008/10/112
+  \href{https://dx.doi.org/10.1088/1126-6708/2008/10/112}{doi:10.1088/1126-6708/2008/10/112}
   [arXiv:0807.1666 [hep-th]].
 
 \bibitem{Sasaki:2012ka}
   S.~Sasaki, M.~Yamaguchi and D.~Yokoyama,
   %``Supersymmetric DBI inflation,''
   Phys.\ Lett.\ B {\bf 718}, 1 (2012)
-  doi:10.1016/j.physletb.2012.10.006
+  \href{https://dx.doi.org/10.1016/j.physletb.2012.10.006}{doi:10.1016/j.physletb.2012.10.006}
   [arXiv:1205.1353 [hep-th]].
 
 \bibitem{Aoki:2016tod}
   S.~Aoki and Y.~Yamada,
   %``More on DBI action in 4D $ \mathcal{N} $ = 1 supergravity,''
   JHEP {\bf 1701}, 121 (2017)
-  doi:10.1007/JHEP01(2017)121
+  \href{https://dx.doi.org/10.1007/JHEP01(2017)121}{doi:10.1007/JHEP01(2017)121}
   [arXiv:1611.08426 [hep-th]].
 
 \bibitem{Nath:2018xxe}
   P.~Nath and M.~Piskunov,
   %``Supersymmetric Dirac-Born-Infeld Axionic Inflation and Non-Gaussianity,''
   JHEP {\bf 1902}, 034 (2019)
-  doi:10.1007/JHEP02(2019)034
+  \href{https://dx.doi.org/10.1007/JHEP02(2019)034}{doi:10.1007/JHEP02(2019)034}
   [arXiv:1807.02549 [hep-ph]].
 
 \bibitem{Lyth:1996im}
   D.~H.~Lyth,
   %``What would we learn by detecting a gravitational wave signal in the cosmic microwave background anisotropy?,''
   Phys.\ Rev.\ Lett.\  {\bf 78}, 1861 (1997)
-  doi:10.1103/PhysRevLett.78.1861
+  \href{https://dx.doi.org/10.1103/PhysRevLett.78.1861}{doi:10.1103/PhysRevLett.78.1861}
   [hep-ph/9606387].
 
 \bibitem{ArkaniHamed:2006dz}
   N.~Arkani-Hamed, L.~Motl, A.~Nicolis and C.~Vafa,
   %``The String landscape, black holes and gravity as the weakest force,''
   JHEP {\bf 0706}, 060 (2007)
-  doi:10.1088/1126-6708/2007/06/060
+  \href{https://dx.doi.org/10.1088/1126-6708/2007/06/060}{doi:10.1088/1126-6708/2007/06/060}
   [hep-th/0601001].
 
 \bibitem{Cheung:2014vva}
   C.~Cheung and G.~N.~Remmen,
   %``Naturalness and the Weak Gravity Conjecture,''
   Phys.\ Rev.\ Lett.\  {\bf 113}, 051601 (2014)
-  doi:10.1103/PhysRevLett.113.051601
+  \href{https://dx.doi.org/10.1103/PhysRevLett.113.051601}{doi:10.1103/PhysRevLett.113.051601}
   [arXiv:1402.2287 [hep-ph]].
 
 \bibitem{Banks:2003sx}
   T.~Banks, M.~Dine, P.~J.~Fox and E.~Gorbatov,
   %``On the possibility of large axion decay constants,''
   JCAP {\bf 0306}, 001 (2003)
-  doi:10.1088/1475-7516/2003/06/001
+  \href{https://dx.doi.org/10.1088/1475-7516/2003/06/001}{doi:10.1088/1475-7516/2003/06/001}
   [hep-th/0303252].
 
 \bibitem{BlancoPillado:2004ns}
   J.~J.~Blanco-Pillado, C.~P.~Burgess, J.~M.~Cline, C.~Escoda, M.~Gomez-Reino, R.~Kallosh, A.~D.~Linde and F.~Quevedo,
   %``Racetrack inflation,''
   JHEP {\bf 0411}, 063 (2004)
-  doi:10.1088/1126-6708/2004/11/063
+  \href{https://dx.doi.org/10.1088/1126-6708/2004/11/063}{doi:10.1088/1126-6708/2004/11/063}
   [hep-th/0406230].
 
 \bibitem{Lalak:2005hr}
   Z.~Lalak, G.~G.~Ross and S.~Sarkar,
   %``Racetrack inflation and assisted moduli stabilisation,''
   Nucl.\ Phys.\ B {\bf 766}, 1 (2007)
-  doi:10.1016/j.nuclphysb.2006.06.041
+  \href{https://dx.doi.org/10.1016/j.nuclphysb.2006.06.041}{doi:10.1016/j.nuclphysb.2006.06.041}
   [hep-th/0503178].
 
 \bibitem{Greene:2005rn}
   B.~Greene and A.~Weltman,
   %``An Effect of alpha' corrections on racetrack inflation,''
   JHEP {\bf 0603}, 035 (2006)
-  doi:10.1088/1126-6708/2006/03/035
+  \href{https://dx.doi.org/10.1088/1126-6708/2006/03/035}{doi:10.1088/1126-6708/2006/03/035}
   [hep-th/0512135].
 
 \bibitem{BlancoPillado:2006he}
   J.~J.~Blanco-Pillado, C.~P.~Burgess, J.~M.~Cline, C.~Escoda, M.~Gomez-Reino, R.~Kallosh, A.~D.~Linde and F.~Quevedo,
   %``Inflating in a better racetrack,''
   JHEP {\bf 0609}, 002 (2006)
-  doi:10.1088/1126-6708/2006/09/002
+  \href{https://dx.doi.org/10.1088/1126-6708/2006/09/002}{doi:10.1088/1126-6708/2006/09/002}
   [hep-th/0603129].
 
 \bibitem{Brown:2015iha}
   J.~Brown, W.~Cottrell, G.~Shiu and P.~Soler,
   %``Fencing in the Swampland: Quantum Gravity Constraints on Large Field Inflation,''
   JHEP {\bf 1510}, 023 (2015)
-  doi:10.1007/JHEP10(2015)023
+  \href{https://dx.doi.org/10.1007/JHEP10(2015)023}{doi:10.1007/JHEP10(2015)023}
   [arXiv:1503.04783 [hep-th]].
 
 \bibitem{Heidenreich:2015wga}
   B.~Heidenreich, M.~Reece and T.~Rudelius,
   %``Weak Gravity Strongly Constrains Large-Field Axion Inflation,''
   JHEP {\bf 1512}, 108 (2015)
-  doi:10.1007/JHEP12(2015)108
+  \href{https://dx.doi.org/10.1007/JHEP12(2015)108}{doi:10.1007/JHEP12(2015)108}
   [arXiv:1506.03447 [hep-th]].
 
 \bibitem{Rudelius:2015xta}
   T.~Rudelius,
   %``Constraints on Axion Inflation from the Weak Gravity Conjecture,''
   JCAP {\bf 1509}, no. 09, 020 (2015)
-  doi:10.1088/1475-7516/2015/09/020, 10.1088/1475-7516/2015/9/020
+  \href{https://dx.doi.org/10.1088/1475-7516/2015/09/020}{doi:10.1088/1475-7516/2015/09/020}
   [arXiv:1503.00795 [hep-th]].
 
 \bibitem{Rudelius:2014wla}
   T.~Rudelius,
   %``On the Possibility of Large Axion Moduli Spaces,''
   JCAP {\bf 1504}, no. 04, 049 (2015)
-  doi:10.1088/1475-7516/2015/04/049
+  \href{https://dx.doi.org/10.1088/1475-7516/2015/04/049}{doi:10.1088/1475-7516/2015/04/049}
   [arXiv:1409.5793 [hep-th]].
 
 \bibitem{Bachlechner:2014gfa}
   T.~C.~Bachlechner, C.~Long and L.~McAllister,
   %``Planckian Axions in String Theory,''
   JHEP {\bf 1512}, 042 (2015)
-  doi:10.1007/JHEP12(2015)042
+  \href{https://dx.doi.org/10.1007/JHEP12(2015)042}{doi:10.1007/JHEP12(2015)042}
   [arXiv:1412.1093 [hep-th]].
 
 \bibitem{Choi:2014rja}
   K.~Choi, H.~Kim and S.~Yun,
   %``Natural inflation with multiple sub-Planckian axions,''
   Phys.\ Rev.\ D {\bf 90}, 023545 (2014)
-  doi:10.1103/PhysRevD.90.023545
+  \href{https://dx.doi.org/10.1103/PhysRevD.90.023545}{doi:10.1103/PhysRevD.90.023545}
   [arXiv:1404.6209 [hep-th]].
 
 \bibitem{Hebecker:2015rya}
   A.~Hebecker, P.~Mangat, F.~Rompineve and L.~T.~Witkowski,
   %``Winding out of the Swamp: Evading the Weak Gravity Conjecture with F-term Winding Inflation?,''
   Phys.\ Lett.\ B {\bf 748}, 455 (2015)
-  doi:10.1016/j.physletb.2015.07.026
+  \href{https://dx.doi.org/10.1016/j.physletb.2015.07.026}{doi:10.1016/j.physletb.2015.07.026}
   [arXiv:1503.07912 [hep-th]].
 
 \bibitem{Conlon:2016aea}
   J.~P.~Conlon and S.~Krippendorf,
   %``Axion decay constants away from the lamppost,''
   JHEP {\bf 1604}, 085 (2016)
-  doi:10.1007/JHEP04(2016)085
+  \href{https://dx.doi.org/10.1007/JHEP04(2016)085}{doi:10.1007/JHEP04(2016)085}
   [arXiv:1601.00647 [hep-th]].
 
 \bibitem{Montero:2015ofa}
   M.~Montero, A.~M.~Uranga and I.~Valenzuela,
   %``Transplanckian axions!?,''
   JHEP {\bf 1508}, 032 (2015)
-  doi:10.1007/JHEP08(2015)032
+  \href{https://dx.doi.org/10.1007/JHEP08(2015)032}{doi:10.1007/JHEP08(2015)032}
   [arXiv:1503.03886 [hep-th]].
 
 \bibitem{Junghans:2015hba}
   D.~Junghans,
   %``Large-Field Inflation with Multiple Axions and the Weak Gravity Conjecture,''
   JHEP {\bf 1602}, 128 (2016)
-  doi:10.1007/JHEP02(2016)128
+  \href{https://dx.doi.org/10.1007/JHEP02(2016)128}{doi:10.1007/JHEP02(2016)128}
   [arXiv:1504.03566 [hep-th]].
 
 \end{thebibliography}

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -1031,13 +1031,6 @@ This research was supported in part by the NSF Grant PHY-1620575.
   Nucl.\ Phys.\ B {\bf 227}, 121 (1983).
   \href{https://dx.doi.org/10.1016/0550-3213(83)90145-1}{doi:10.1016/0550-3213(83)90145-1}
 
-\bibitem{Balasubramanian:2005zx}
-  V.~Balasubramanian, P.~Berglund, J.~P.~Conlon and F.~Quevedo,
-  %``Systematics of moduli stabilisation in Calabi-Yau flux compactifications,''
-  JHEP {\bf 0503}, 007 (2005)
-  \href{https://dx.doi.org/10.1088/1126-6708/2005/03/007}{doi:10.1088/1126-6708/2005/03/007}
-  \href{https://arxiv.org/abs/hep-th/0502058}{[hep-th/0502058]}.
-
 \bibitem{Khoury:2010gb}
   J.~Khoury, J.~L.~Lehners and B.~Ovrut,
   %``Supersymmetric P(X,$\phi$) and the Ghost Condensate,''

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -835,7 +835,7 @@ This research was supported in part by the NSF Grant PHY-1620575.
 \bibitem{Sato:1980yn}
   K.~Sato,
   %``First Order Phase Transition of a Vacuum and Expansion of the Universe,''
-  Mon.\ Not.\ Roy.\ Astron.\ Soc.\  {\bf 195}, 467 (1981).
+  \href{http://articles.adsabs.harvard.edu/full/1981MNRAS.195..467S}{Mon.\ Not.\ Roy.\ Astron.\ Soc.\  {\bf 195}, 467 (1981)}.
 
 \bibitem{Linde:1983gd}
   A.~D.~Linde,
@@ -847,7 +847,7 @@ This research was supported in part by the NSF Grant PHY-1620575.
   V.~F.~Mukhanov and G.~V.~Chibisov,
   %``Quantum Fluctuations and a Nonsingular Universe,''
   JETP Lett.\  {\bf 33}, 532 (1981)
-  [Pisma Zh.\ Eksp.\ Teor.\ Fiz.\  {\bf 33}, 549 (1981)].
+  \href{http://inspirehep.net/record/170051/files/article_23079.pdf?version=1}{[Pisma Zh.\ Eksp.\ Teor.\ Fiz.\  {\bf 33}, 549 (1981)]}.
 
 \bibitem{Hawking:1982cz}
   S.~W.~Hawking,

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -908,28 +908,28 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Natural inflation: Particle physics models, power law spectra for large scale structure, and constraints from COBE,''
   Phys.\ Rev.\ D {\bf 47}, 426 (1993)
   \href{https://dx.doi.org/10.1103/PhysRevD.47.426}{doi:10.1103/PhysRevD.47.426}
-  [hep-ph/9207245].
+  \href{https://arxiv.org/abs/hep-ph/9207245}{[hep-ph/9207245]}.
 
 \bibitem{Banks:2003sx}
   T.~Banks, M.~Dine, P.~J.~Fox and E.~Gorbatov,
   %``On the possibility of large axion decay constants,''
   JCAP {\bf 0306}, 001 (2003)
   \href{https://dx.doi.org/10.1088/1475-7516/2003/06/001}{doi:10.1088/1475-7516/2003/06/001}
-  [hep-th/0303252].
+  \href{https://arxiv.org/abs/hep-th/0303252}{[hep-th/0303252]}.
 
 \bibitem{Svrcek:2006yi}
   P.~Svrcek and E.~Witten,
   %``Axions In String Theory,''
   JHEP {\bf 0606}, 051 (2006)
   \href{https://dx.doi.org/10.1088/1126-6708/2006/06/051}{doi:10.1088/1126-6708/2006/06/051}
-  [hep-th/0605206].
+  \href{https://arxiv.org/abs/hep-th/0605206}{[hep-th/0605206]}.
 
 \bibitem{Kim:2004rp}
   J.~E.~Kim, H.~P.~Nilles and M.~Peloso,
   %``Completing natural inflation,''
   JCAP {\bf 0501}, 005 (2005)
   \href{https://dx.doi.org/10.1088/1475-7516/2005/01/005}{doi:10.1088/1475-7516/2005/01/005}
-  [hep-ph/0409138].
+  \href{https://arxiv.org/abs/hep-ph/0409138}{[hep-ph/0409138]}.
 
 \bibitem{Long:2014dta}
   C.~Long, L.~McAllister and P.~McGuirk,
@@ -955,14 +955,14 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Inflating in a better racetrack,''
   JHEP {\bf 0609}, 002 (2006)
   \href{https://dx.doi.org/10.1088/1126-6708/2006/09/002}{doi:10.1088/1126-6708/2006/09/002}
-  [hep-th/0603129].
+  \href{https://arxiv.org/abs/hep-th/0603129}{[hep-th/0603129]}.
 
 \bibitem{Conlon:2005jm}
   J.~P.~Conlon and F.~Quevedo,
   %``Kahler moduli inflation,''
   JHEP {\bf 0601}, 146 (2006)
   \href{https://dx.doi.org/10.1088/1126-6708/2006/01/146}{doi:10.1088/1126-6708/2006/01/146}
-  [hep-th/0509012].
+  \href{https://arxiv.org/abs/hep-th/0509012}{[hep-th/0509012]}.
 
 \bibitem{Ben-Dayan:2014lca}
   I.~Ben-Dayan, F.~G.~Pedro and A.~Westphal,
@@ -983,7 +983,7 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Gravity and global symmetries,''
   Phys.\ Rev.\ D {\bf 52}, 912 (1995)
   \href{https://dx.doi.org/10.1103/PhysRevD.52.912}{doi:10.1103/PhysRevD.52.912}
-  [hep-th/9502069].
+  \href{https://arxiv.org/abs/hep-th/9502069}{[hep-th/9502069]}.
 
 \bibitem{Chamseddine:1982jx}
   A.~H.~Chamseddine, R.~L.~Arnowitt and P.~Nath,
@@ -1008,14 +1008,14 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``De Sitter vacua in string theory,''
   Phys.\ Rev.\ D {\bf 68}, 046005 (2003)
   \href{https://dx.doi.org/10.1103/PhysRevD.68.046005}{doi:10.1103/PhysRevD.68.046005}
-  [hep-th/0301240].
+  \href{https://arxiv.org/abs/hep-th/0301240}{[hep-th/0301240]}.
 
 \bibitem{Balasubramanian:2005zx}
   V.~Balasubramanian, P.~Berglund, J.~P.~Conlon and F.~Quevedo,
   %``Systematics of moduli stabilisation in Calabi-Yau flux compactifications,''
   JHEP {\bf 0503}, 007 (2005)
   \href{https://dx.doi.org/10.1088/1126-6708/2005/03/007}{doi:10.1088/1126-6708/2005/03/007}
-  [hep-th/0502058].
+  \href{https://arxiv.org/abs/hep-th/0502058}{[hep-th/0502058]}.
 
 \bibitem{Khoury:2010gb}
   J.~Khoury, J.~L.~Lehners and B.~Ovrut,
@@ -1050,14 +1050,14 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``Partial breaking of global D = 4 supersymmetry, constrained superfields, and three-brane actions,''
   Phys.\ Rev.\ D {\bf 59}, 106001 (1999)
   \href{https://dx.doi.org/10.1103/PhysRevD.59.106001}{doi:10.1103/PhysRevD.59.106001}
-  [hep-th/9811232].
+  \href{https://arxiv.org/abs/hep-th/9811232}{[hep-th/9811232]}.
 
 \bibitem{Tseytlin:1999dj}
   A.~A.~Tseytlin,
   %``Born-Infeld action, supersymmetry and string theory,''
   In *Shifman, M.A. (ed.): The many faces of the superworld* 417-452
   \href{https://dx.doi.org/10.1142/9789812793850\_0025}{doi:10.1142/9789812793850\_0025}
-  [hep-th/9908105].
+  \href{https://arxiv.org/abs/hep-th/9908105}{[hep-th/9908105]}.
 
 \bibitem{Ito:2007hy}
   K.~Ito, H.~Nakajima and S.~Sasaki,
@@ -1099,14 +1099,14 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``What would we learn by detecting a gravitational wave signal in the cosmic microwave background anisotropy?,''
   Phys.\ Rev.\ Lett.\  {\bf 78}, 1861 (1997)
   \href{https://dx.doi.org/10.1103/PhysRevLett.78.1861}{doi:10.1103/PhysRevLett.78.1861}
-  [hep-ph/9606387].
+  \href{https://arxiv.org/abs/hep-ph/9606387}{[hep-ph/9606387]}.
 
 \bibitem{ArkaniHamed:2006dz}
   N.~Arkani-Hamed, L.~Motl, A.~Nicolis and C.~Vafa,
   %``The String landscape, black holes and gravity as the weakest force,''
   JHEP {\bf 0706}, 060 (2007)
   \href{https://dx.doi.org/10.1088/1126-6708/2007/06/060}{doi:10.1088/1126-6708/2007/06/060}
-  [hep-th/0601001].
+  \href{https://arxiv.org/abs/hep-th/0601001}{[hep-th/0601001]}.
 
 \bibitem{Cheung:2014vva}
   C.~Cheung and G.~N.~Remmen,
@@ -1120,35 +1120,35 @@ This research was supported in part by the NSF Grant PHY-1620575.
   %``On the possibility of large axion decay constants,''
   JCAP {\bf 0306}, 001 (2003)
   \href{https://dx.doi.org/10.1088/1475-7516/2003/06/001}{doi:10.1088/1475-7516/2003/06/001}
-  [hep-th/0303252].
+  \href{https://arxiv.org/abs/hep-th/0303252}{[hep-th/0303252]}.
 
 \bibitem{BlancoPillado:2004ns}
   J.~J.~Blanco-Pillado, C.~P.~Burgess, J.~M.~Cline, C.~Escoda, M.~Gomez-Reino, R.~Kallosh, A.~D.~Linde and F.~Quevedo,
   %``Racetrack inflation,''
   JHEP {\bf 0411}, 063 (2004)
   \href{https://dx.doi.org/10.1088/1126-6708/2004/11/063}{doi:10.1088/1126-6708/2004/11/063}
-  [hep-th/0406230].
+  \href{https://arxiv.org/abs/hep-th/0406230}{[hep-th/0406230]}.
 
 \bibitem{Lalak:2005hr}
   Z.~Lalak, G.~G.~Ross and S.~Sarkar,
   %``Racetrack inflation and assisted moduli stabilisation,''
   Nucl.\ Phys.\ B {\bf 766}, 1 (2007)
   \href{https://dx.doi.org/10.1016/j.nuclphysb.2006.06.041}{doi:10.1016/j.nuclphysb.2006.06.041}
-  [hep-th/0503178].
+  \href{https://arxiv.org/abs/hep-th/0503178}{[hep-th/0503178]}.
 
 \bibitem{Greene:2005rn}
   B.~Greene and A.~Weltman,
   %``An Effect of alpha' corrections on racetrack inflation,''
   JHEP {\bf 0603}, 035 (2006)
   \href{https://dx.doi.org/10.1088/1126-6708/2006/03/035}{doi:10.1088/1126-6708/2006/03/035}
-  [hep-th/0512135].
+  \href{https://arxiv.org/abs/hep-th/0512135}{[hep-th/0512135]}.
 
 \bibitem{BlancoPillado:2006he}
   J.~J.~Blanco-Pillado, C.~P.~Burgess, J.~M.~Cline, C.~Escoda, M.~Gomez-Reino, R.~Kallosh, A.~D.~Linde and F.~Quevedo,
   %``Inflating in a better racetrack,''
   JHEP {\bf 0609}, 002 (2006)
   \href{https://dx.doi.org/10.1088/1126-6708/2006/09/002}{doi:10.1088/1126-6708/2006/09/002}
-  [hep-th/0603129].
+  \href{https://arxiv.org/abs/hep-th/0603129}{[hep-th/0603129]}.
 
 \bibitem{Brown:2015iha}
   J.~Brown, W.~Cottrell, G.~Shiu and P.~Soler,


### PR DESCRIPTION
## Changes
* Closes #10.
* Adds live clickable URLs to doi and arXiv IDs.
* Adds URLs to remaining references that have neither doi ID nor arXiv ID.
* Removes duplicate and unused references.
* Sorts references in the order cited in the text.

## Tests and commands
* Build with `./build.sh` to get [coherent-enhancement.pdf](https://github.com/maxitg/coherent-enhancement/files/3243007/coherent-enhancement.pdf).