### PR TITLE
arXiv build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 ## macOS files
 *.DS_Store
 
-## Compiled pdf
+## Compiled paper
 *.pdf
+*.tar.gz
 
 ## Figures
 /figures/

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,38 @@
 #!/bin/bash
 
+usage() { cat << EOF
+usage: ./build.sh [-ah][-p <pointCountMultiplier>]
+
+  a : make .tar.gz suitable for arXiv upload
+  h : print this usage message
+
+  p multiplier : produce the paper with p times the normal number of points
+                 on scatter plots
+EOF
+exit 1;
+}
+
 pointCountMultiplier=1.0
-while getopts p: option
-do
-  case "${option}"
-    in
-    p) pointCountMultiplier=${OPTARG};;
+while getopts "p:ah" option; do
+  case "${option}" in
+    p)
+      pointCountMultiplier=${OPTARG};;
+    a)
+      createArxivFile=true;;
+    *)
+      usage;;
   esac
 done
+
+if [ "$createArxivFile" = true ] ; then
+  rm -rf figures
+fi
 
 ./computeSimulations.wls $pointCountMultiplier &&
 pdflatex coherent-enhancement.tex &&
 pdflatex coherent-enhancement.tex &&
 pdflatex coherent-enhancement.tex
+
+if [ "$createArxivFile" = true ] ; then
+  tar -cvzf coherent-enhancement-arxiv.tar.gz coherent-enhancement.tex figures
+fi

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -1,4 +1,5 @@
 \documentclass[12pt]{article}
+\pdfoutput=1
 
 \usepackage{amsmath} % math
 \usepackage{amssymb} % additional math symbols


### PR DESCRIPTION
## Changes
* Closes #52.
* Adds `-a` option to `./build.sh` which will create a `.tar.gz` file for arXiv at the end of compilation.
* Adds `-h` option to `./build.sh` which will list all options.
* Adds `\pdfoutput=1` to `.tex` file to enforce `pdflatex` mode of compilation by arXiv.

## Commands and tests
* Run `./build.sh -h` to see the usage message.
```
usage: ./build.sh [-ah][-p <pointCountMultiplier>]

  a : make .tar.gz suitable for arXiv upload
  h : print this usage message

  p multiplier : produce the paper with p times the normal number of points
                 on scatter plots
```
---
* Run `./build.sh -a`.
* `coherent-enhancement-arxiv.tar.gz` file should be created in the root repository directory.
* Unpack the file to check that it contains both `.tex` file and figures, and is compilable by `pdflatex`.