### PR TITLE
Remove double Planck units

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -36,7 +36,7 @@ The coherent enhancement mechanism allows one to reduce an inflation model with 
 We demonstrate that this approach can predict the number of e-foldings in a given inflation model without the need for numerical simulation.
 Further we show that the effective decay constant $f_e$ can be directly related to the spectral indices so that $f_e = M_\text{P} / \sqrt{1 - n_s - r / 4}$ where $n_s$ is the spectral index for curvature perturbations and $r$ is the ratio of the power spectrum of tensor perturbations and curvature perturbations.
 The current data on $n_s$ and $r$ constrains the effective axion decay constant so that $4.9 \leq f_e / M_\text{P} \leq 10.0$ at $95\%$ CL.
-Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 10 M_\text{P}$ in units of Planck mass in axion cosmology for any potential-based model which produces successful inflation.
+Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 10 M_\text{P}$ in axion cosmology for any potential-based model which produces successful inflation.
 The coherent enhancement mechanism for the generation of an effective $f_e > M_\text{P}$ while the true axion decay constant $f < M_\text{P}$ is discussed.
 We illustrate the coherent enhancement in globally supersymmetric models and supergravity models.
 We also show that $f_e$ based on inflation dynamics can be defined for non-potential-based models, and consider a Dirac-Born-Infeld model as an example.


### PR DESCRIPTION
## Changes
* Removes double reference to Planck units from abstract.