### PR TITLE
Add equation for r in terms of derivative of density with respect to e-foldings

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -735,14 +735,15 @@ If we now require $\Delta \phi < M_\text{P}$, which for types of models we consi
 \end{equation}
 which is what we see in Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}).
 Note also $\Delta\phi$ is larger in the supergravity model, which is consistent with it also producing larger values of $r$.
-The density in that case stays nearly constant at horizon exit since
+The density in that case stays nearly constant at horizon exit since we get using the first Friedmann equation
 \begin{equation}
-  \epsilon \approx \epsilon_H
-           = - \frac{\dot H}{H^2}
-           = - \frac{8 \sqrt{3} \dot\rho M_\text{P}}{\rho^{3 / 2}}
-           \propto \dot\rho\,,
+  r \approx 16 \epsilon_H
+          = - 16 \frac{\dot H}{H^2}
+          = - \frac{128 \sqrt{3} \dot\rho M_\text{P}}{\rho^{3 / 2}}
+          = - \frac{128}{\rho} \frac{d\rho}{dN}\,,
 \end{equation}
-which can be seen in the top panels of Fig.~(\ref{fig:density}).
+where $N$ is the number of e-foldings.
+We can also see that in the top panels of Fig.~(\ref{fig:density}).
 
 In the case of DBI, however, Eq.~(\ref{eq:efoldingsCanonical}) is not valid, rather, $\dot\phi$ in the denominator of Eq.~(\ref{eq:efoldingsGeneral}) is suppressed by the kinetic term in Eq.~(\ref{eq:dbi:lagrangian} as $\rho \rightarrow \infty$ for $\phi = b_- \rightarrow b_{-, \text{max}} \sim \sqrt{T} / M_\text{P}$.
 It is then possible to obtain a large number of e-foldings by increasing $\rho$, which can be done for example by having $\tilde\beta \gg 1$ in Eq.~(\ref{eq:dbi:beta}).


### PR DESCRIPTION
## Changes
* Closes #58.
* Replaces equation for slow-roll epsilon in terms of time-derivative of density with an equation for tensor-to-scalar ratio r in terms of e-foldings-derivative of density.

<img width="526" alt="Screen Shot 2019-06-01 at 14 39 45" src="https://user-images.githubusercontent.com/1479325/58752830-1afad200-847b-11e9-8582-8caf9c471f4d.png">