### PR TITLE
$\eta_H$ and $f_{eH}$ from density

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -792,13 +792,19 @@ Thus for the case when sound velocity $c_s \sim 1$, $r$ can be approximated as f
 \begin{equation} \label{eq:rFromDDensityDN}
   r \approx 16 \epsilon_H
           = - 16 \frac{\dot H}{H^2}
-          = - \frac{128 \sqrt{3} \dot\rho M_\text{P}}{\rho^{3 / 2}}
-          = - \frac{128}{\rho} \frac{d\rho}{dN}\,.
+          = - \frac{8 \sqrt{3} \dot\rho M_\text{P}}{\rho^{3 / 2}}
+          = - \frac{8}{\rho} \frac{d\rho}{dN}\,.
 \end{equation}
 From the plot of $\rho / \rho_0$ as a function of $N - N_{\text{total}}$ one finds that $\frac{d\rho}{dN}$ is very small for the top panels of Fig.~(\ref{fig:density}) in the domain of horizon exit, i.e., $-60 < N - N_\text{total} < -50$ and leads to $r \sim O\left(10^{-4}\right)$.
 On the other hand for the DBI case $\frac{d\rho}{dN}$ is visibly much larger as can be seen by the bottom panel of Fig.~(\ref{fig:density}).
 Thus explains why $r$ is much larger for the DBI case than for the case where inflation is driven by the potential which is the case for the top panels of Fig.~(\ref{fig:density}).
 From the above analysis it also follows that the Lyth bound Eq.~(\ref{eq:LythBound}) is not valid for DBI and more generally for the case where inflation is driven by the full Lagrangian and not just by the potential.
+
+It is possible to express $\eta_H$ and $f_{eH}$ in terms of density as well so that
+\begin{align}
+  \eta_H = \frac{d\rho / dN}{\rho} - \frac{d^2\rho / \left(dN\right)^2}{d\rho / dN}\,,\\
+  f_{eH} = M_\text{P} \left/ \sqrt{2 \frac{d\rho / dN}{\rho} - \frac{d^2\rho / \left(dN\right)^2}{d\rho / dN}} \right.\,.
+\end{align}
 
 \section{Conclusion \label{sec:Conclusion}}
 One of the possible candidates for an inflaton is an axion.


### PR DESCRIPTION
## Changes
* Closes #61.
* Fixes a mistake in the equation for tensor-to-scalar ratio $r$ in terms of density (there was an extra factor of 16):
<img width="719" alt="Screen Shot 2019-06-02 at 22 34 28" src="https://user-images.githubusercontent.com/1479325/58774343-985f3900-8586-11e9-959b-f39f71ad54bb.png">
* Adds equations for $\eta_H$ and $f_{eH}$ in terms of derivatives of density with respect to the number of e-foldings:
<img width="969" alt="Screen Shot 2019-06-02 at 22 34 57" src="https://user-images.githubusercontent.com/1479325/58774358-a8771880-8586-11e9-9538-e42b27f4eec5.png">