### PR TITLE
Improvements to observables from density

### DIFF
--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -245,13 +245,13 @@ To distinguish the effective decay constant computed in this way from $f_e$ that
 Specifically, we can define dynamic slow-roll parameters
 \begin{equation} \label{eq:slowRollParametersDynamic}
   \epsilon_H = -\frac{\dot H}{H^2}\,,
-  ~~~ \eta_H = -\frac{\dot{\epsilon_H}}{\epsilon_H H}\,,
-  ~~~ \sigma_H = -\frac{1}{H} \frac{d}{dt} \ln c_s\,,
+  ~~~ \eta_H = \frac{\dot{\epsilon_H}}{\epsilon_H H}\,,
+  ~~~ \sigma_H = \frac{1}{H} \frac{d}{dt} \ln c_s\,,
 \end{equation}
 where $c_s$ is the speed of sound in the medium where $c_s^2 = p_{,\beta} / \rho_{,\beta}$, $\beta = \dot\phi^2$, where $p$ is the pressure and $\rho$ the density.
 In this case spectral indices are given by~\cite{Garriga:1999vw, Spalinski:2007qy}
 \begin{equation}
-      n_s = 1 - 2 \epsilon_H + \eta_H + \sigma_H,
+      n_s = 1 - 2 \epsilon_H - \eta_H - \sigma_H,
   ~~~ n_t = - 2\epsilon_H\,.
 \end{equation}
 
@@ -816,12 +816,12 @@ Thus for the case when sound velocity $c_s \sim 1$, one can obtain the slow-roll
 \begin{equation}
   \begin{aligned}
     \epsilon_H &= -\frac{1}{2 \rho} \frac{d\rho}{dN}\,,\\
-    \eta_H &= \frac{1}{\rho} \frac{d\rho}{dN} - \frac{d^2\rho}{dN^2} / \frac{d\rho}{dN}\,.
+    \eta_H &= -\frac{1}{\rho} \frac{d\rho}{dN} + \left.\frac{d^2\rho}{dN^2} \middle/ \frac{d\rho}{dN}\right.\,.
   \end{aligned}
 \end{equation}
 Further, the enhancement factor $f_{eH}$ is given by
 \begin{equation}
-  f_{eH} = M_{Pl} \left/ \sqrt{2 \frac{\frac{d\rho}{dN}}{\rho} - \left.\frac{d^2\rho}{dN^2} \middle/ \frac{d\rho}{dN}\right.}\right.\,.
+  f_{eH} = M_{Pl} \sqrt{\left.\frac{d\rho}{dN} \middle/ \frac{d^2\rho}{dN^2}\right.}\,.
 \end{equation}
 Similarly the spectral index $n_s$ and the ratio $r$ of the tensor to scalar power spectrum are given by
 \begin{equation} \label{eq:rFromDDensityDN}

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -1,5 +1,3 @@
-
-    
 \documentclass[12pt]{article}
 \pdfoutput=1
 
@@ -13,7 +11,7 @@
 \usepackage[numbers, sort & compress]{natbib} % cleanup citations
 \usepackage{parskip} % add vertical space between paragraphs
 \usepackage[section]{placeins} % keep figures inside their sections
-\newcommand{\rr}[1]{{\color{red}{#1}}}
+
 \author{
   Pran Nath\footnote{Email: p.nath@northeastern.edu}~\ and
   Maksim Piskunov\footnote{Email: m.piskunov@northeastern.edu}\\~\\
@@ -22,8 +20,7 @@
 }
 
 \title{
-  Enhancement 
-   of the Axion Decay Constant in Inflation and the Weak Gravity Conjecture
+  Enhancement of the Axion Decay Constant in Inflation and the Weak Gravity Conjecture
 }
 
 \begin{document}
@@ -46,10 +43,8 @@ We demonstrate that this approach can predict the number of e-foldings in a give
 Further we show that the effective decay constant $f_e$ can be directly related to the spectral indices so that $f_e = M_{Pl} / \sqrt{1 - n_s - r / 4}$ where $n_s$ is the spectral index for curvature perturbations and $r$ is the ratio of the power spectrum of tensor perturbations and curvature perturbations.
 The current data on $n_s$ and $r$ constrains the effective axion decay constant so that $4.9 \leq f_e / M_{Pl} \leq 10.0$ at $95\%$ CL.
 Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 10 M_{Pl}$ in axion cosmology for any potential-based model which produces successful inflation.
-For the Dirac-Born-Infeld inflation
- and more generally k-flation
- CEM is not applicable. 
- Nonetheless in this case also we show that successful inflation can occur with $f < M_\text{P}$. 
+For the Dirac-Born-Infeld inflation and more generally k-flation CEM is not applicable.
+Nonetheless in this case also we show that successful inflation can occur with $f < M_{Pl}$.
 Further, one can define a more general effective axion decay constant valid for inflation controlled either by flat potentials or by k-flation.
 In the models considered in this work, all the moduli are stabilized and the inflationary model in each case is consistent with astrophysical observations with $f_e > M_{Pl}$ and the axion decay constant of the microscopic theory satisfies $f < M_{Pl}$ consistent with the weak gravity conjecture.
 \footnote{Source code: \url{https://github.com/maxitg/coherent-enhancement}}
@@ -93,8 +88,7 @@ Conclusions are given in section \ref{sec:Conclusion}.
 Some relevant papers related to this work can be found in \cite{BlancoPillado:2006he, Conlon:2005jm, Ben-Dayan:2014lca, Gao:2014uha}.
 
 \section{The weak gravity conjecture and axion inflation \label{sec:WeakGravityConjecture}}
-In its simplest form the weak gravity conjecture (WGC) considers the coupling of an abelian gauge field with gravity and states that this system must contain a particle of charge $q$ and mass $m$ so that~\cite{ArkaniHamed:2006dz} $\frac{q}{m} > \frac{1}{M_{Pl}}$, 
-where $M_{Pl}$ is the reduce Planck mass defined by $M_{Pl}= (8\pi G_N)^{-1/2}$ and $G_N$ is Newton's constant. 
+In its simplest form the weak gravity conjecture (WGC) considers the coupling of an abelian gauge field with gravity and states that this system must contain a particle of charge $q$ and mass $m$ so that~\cite{ArkaniHamed:2006dz} $\frac{q}{m} > \frac{1}{M_{Pl}}$, where $M_{Pl}$ is the reduced Planck mass defined by $M_{Pl} = \left(8 \pi G_N\right)^{-1 / 2}$ and $G_N$ is the Newton's constant.
 The existence of such a particle is needed to carry away the charge of a black hole to avoid the remnant problem when the black hole evaporates due to Hawking radiation.
 The above constraint is found to be consistent with string theory and thus one might argue that consistent theories of quantum gravity obey the weak gravity conjecture.
 Specifically, for example, one cannot let the charge $q$ become arbitrarily small since in that case in the limit one will have a continuous global symmetry which is forbidden by strings.
@@ -136,10 +130,10 @@ To have a flat direction in the field space one imposes the constraint
 \end{equation}
 A small correction to the constraint gives inflaton a mass and produces an effective axion decay constant larger that $f$.
 For example, if one considers $f_1 = f_2 = f_3 = f$, $f_4 = f\left(1 + \delta\right)$, and $\Lambda_1 = \Lambda_2$, the inflaton field in this case will have an effective axion decay constant $f_e \sim f / \delta$.
-\rr{(For a discussion on implementing the mechanism with  stabilized moduli in string models see, e.g.,~\cite{Long:2014dta}.)}
+(For a discussion on implementing the mechanism with stabilized moduli in string models see, e.g.,~\cite{Long:2014dta}.)
 Below we discuss the coherent enhancement mechanism (CEM) that can lead to an effective axion decay constant that controls inflation and is much larger than the true decay constant.
-\rr{Further, we exhibit this phenomenon in models based on supersymmetry and supergravity. Later we discuss the
-DBI-enhacement which enters in Dirac-Born-Infeld inflationary models.}
+Further, we exhibit this phenomenon in models based on supersymmetry and supergravity.
+Later we discuss the DBI-enhacement which enters in Dirac-Born-Infeld inflationary models.
 
 \section{General analysis of coherent enhancement mechanism \label{sec:CoherentEnhancement}}
 As mentioned in section \ref{sec:Introduction}, coherent enhancement mechanism works for slow roll inflation arising from a flat potential.
@@ -254,15 +248,14 @@ Specifically, we can define dynamic slow-roll parameters
   ~~~ \eta_H = -\frac{\dot{\epsilon_H}}{\epsilon_H H}\,,
   ~~~ \sigma_H = -\frac{1}{H} \frac{d}{dt} \ln c_s\,,
 \end{equation}
-where $c_s$ is the speed of sound in the medium \rr{where $c_s^2= p_{,\beta}/\rho_{,\eta}$, $\beta= \dot \phi^2$
-where $p$ is the pressure and $\rho$ the density. }
+where $c_s$ is the speed of sound in the medium where $c_s^2 = p_{,\beta} / \rho_{,\beta}$, $\beta = \dot\phi^2$, where $p$ is the pressure and $\rho$ the density.
 In this case spectral indices are given by~\cite{Garriga:1999vw, Spalinski:2007qy}
 \begin{equation}
       n_s = 1 - 2 \epsilon_H + \eta_H + \sigma_H,
   ~~~ n_t = - 2\epsilon_H\,.
 \end{equation}
 
-For the case when the  dependence \rr{on sound speed $c_s$} of the parameters is relatively small one has
+For the case when the dependence on sound speed $c_s$ of the parameters is relatively small one has
 \begin{equation} \label{eq:slowRollParametersDynamicFromStatic}
   \epsilon_H = \epsilon\,,
   ~~~ \eta_H = -2 \eta + 4 \epsilon\,,
@@ -348,6 +341,7 @@ where $V_\text{slow}\left(b_-\right)$ which depends only on $b_-$ enters in slow
     The analysis shows that axion inflation by the parameter points in the blue region is consistent with WGC as exhibited by the top right panel.
   } \label{fig:supersymmetry}
 \end{figure}
+
 Note, the values of the parameters $\mu$ and $\lambda / M$ determine the stability point $f$.
 We can equivalently however fix $f$ and solve for $\lambda / M$ in terms of $\mu$ and $f$.
 It turns out $\mu$ only appears in $V_\text{fast}$, but not in $V_\text{slow}$, for which an explicit form is given by
@@ -378,29 +372,6 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
   \end{aligned}
 \end{equation}
 
-%\begin{figure}
-%  \centering
-%  \begin{subfigure}{0.45 \textwidth}
-%    \includegraphics[width = \textwidth]{figures/supersymmetry_ns_r.pdf}
-%  \end{subfigure}
-%  \begin{subfigure}{0.45 \textwidth}
-%    \includegraphics[width = \textwidth]{figures/supersymmetry_f_fStatic.pdf}
-%  \end{subfigure}
-%  \begin{subfigure}{0.45 \textwidth}
-%    \includegraphics[width = \textwidth]{figures/supersymmetry_potentialRange.pdf}
-%  \end{subfigure}
-%  \caption{\protect\input{figures/supersymmetry.txt}
-%    Top left panel shows tensor-to-scalar ratio vs scalar spectral index.
-%    Blue region encloses the parameter points consistent with Planck 2018 TT,TE,EE+lowE+lensing+BK14+BAO data at $95\%$ CL.
-%    Top right panel exhibits the coherent enhancement of the decay constant.
-%    The bottom panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
-%    Note that because the field is normalized by $f$ and because $G_5$ is fine-tuned, potentials for all considered input parameters look almost identical.
-%    Inflation occurs in the flat region of the potential near $b_- / f \approx 3$.
-%    Here the field transversal during inflation is $\Delta b_- < f \le M_{Pl}$.
-%    The analysis shows that axion inflation by the parameter points in the blue region is consistent with WGC as exhibited by the top right panel.
-%  } \label{fig:supersymmetry}
-%\end{figure}
-
 Here the superposition of several cosines produces local flatness where slow roll can occur.
 In order to verify consistency with experiment and evaluate $f_e$, we use Inflation Simulator\footnote{\url{https://github.com/maxitg/InflationSimulator}}.
 For these simulations we begin by sampling a number of parameter sets as described in the caption of Fig.~(\ref{fig:supersymmetry}).
@@ -413,10 +384,6 @@ One can see that even though the true decay constant $f$ is below $M_{Pl}$, the 
 We find the relative difference between two effective decay constants $\left|f_e - f_{eH}\right| / f_e \le \protect\input{figures/supersymmetryfRelativeDifferenceMax.txt}$.
 We note that fine tuning of $G_5$ is required to achieve coherent enhancement and experimentally-consistent inflation.
 Further the analysis of Fig.~(\ref{fig:supersymmetry}) shows that CEM is operative and $f_e / M_{Pl} \gg 1$ is achieved while $f < M_{Pl}$ consistent with WGC.
-
-
-
-
 
 \section{Supergravity \label{sec:Supergravity}}
 Next we test CEM for supergravity where the scalar potential has the form~\cite{Chamseddine:1982jx, Cremmer:1982en}
@@ -513,13 +480,13 @@ where $C_k$ are given by
   \begin{aligned}
     C_1 &=   4 \left(
         2 e^2 \left(   \frac{M_{Pl}^2}{f^2} + 1 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1^2  }{M_{Pl}^6}
-      +   e^3 \left(                              3 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_2}{M_{Pl}^6}\right.\\
+      +   e^3 \left(                          3 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_2}{M_{Pl}^6}\right.\\
       &~~~~~~ \left.{}
       + 2 e^4 \left( 3 \frac{M_{Pl}^2}{f^2} + 5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_3}{M_{Pl}^6}
       -   e^5 \left(12 \frac{M_{Pl}^2}{f^2} + 7 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2 A_3}{M_{Pl}^6}
     \right)\,,\\
     C_2 &=   2 \left(
-      -   e^2 \left(                              1 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1^2  }{M_{Pl}^6}
+      -   e^2 \left(                          1 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1^2  }{M_{Pl}^6}
       + 4 e^3 \left( 2 \frac{M_{Pl}^2}{f^2} + 3 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_2}{M_{Pl}^6}\right.\\
       &~~~~~~ \left.{}
       + 4 e^4 \left( 4 \frac{M_{Pl}^2}{f^2} + 5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2^2  }{M_{Pl}^6}
@@ -528,20 +495,20 @@ where $C_k$ are given by
       + 4 e^5 \left( 6 \frac{M_{Pl}^2}{f^2} + 7 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2 A_3}{M_{Pl}^6}
     \right)\,,\\
     C_3 &=   4 \left(
-      -   e^3 \left(                              3 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_2}{M_{Pl}^6}
+      -   e^3 \left(                          3 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_2}{M_{Pl}^6}
       + 2 e^4 \left( 3 \frac{M_{Pl}^2}{f^2} + 5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_3}{M_{Pl}^6}\right.\\
       &~~~~~~ \left.{}
       + 2 e^5 \left( 6 \frac{M_{Pl}^2}{f^2} + 7 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2 A_3}{M_{Pl}^6}
       + 2 e^6 \left( 9 \frac{M_{Pl}^2}{f^2} + 9 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_3^2  }{M_{Pl}^6}
     \right)\,,\\
     C_4 &=   2 \left(
-      - 2 e^4 \left(                              5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_3}{M_{Pl}^6}
-      -   e^4 \left(                              5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2^2  }{M_{Pl}^6}
+      - 2 e^4 \left(                          5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_3}{M_{Pl}^6}
+      -   e^4 \left(                          5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2^2  }{M_{Pl}^6}
     \right)\,,\\
     C_5 &= - 4
-          e^5 \left(                              7 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2 A_3}{M_{Pl}^6}\,,\\
+          e^5 \left(                          7 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2 A_3}{M_{Pl}^6}\,,\\
     C_6 &= - 2
-          e^6 \left(                              9 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_3^2  }{M_{Pl}^6}\,.
+          e^6 \left(                          9 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_3^2  }{M_{Pl}^6}\,.
   \end{aligned}
 \end{equation}
 As in the global supersymmetry case of section \ref{sec:Supersymmetry} here also local regions of flatness in the potential appear due to overlaps of several cosines, slow roll can occur and CEM is operative.
@@ -831,7 +798,7 @@ This leads to a relation between $r$ and $\Delta \phi$ so that
     Top right panel: Same as the left panel except it is for the supergravity case.
     Bottom panel: The same as the top left panel except it is for the DBI case.
     The figure explains the reason why $r$ can be much larger for DBI relative to models where slow roll is controlled by flat potentials.
-    From Eq.~(\ref{eq:rFromDDensityr}) we see that $r$ is proportional to $d\rho / dN$.
+    From Eq.~(\ref{eq:rFromDDensityDN}) we see that $r$ is proportional to $d\rho / dN$.
     In the top panels $\rho / \rho_0$ is essentially flat near the horizon exist which is in the interval which occurs at $-60 < N - N_\text{total} < -50$ and leads to $r \sim O\left(10^{-4}\right)$ while for the DBI case in the bottom panel $\rho / \rho_0$ has a significant curvature and $r$ can be as large as $\sim 0.1$.
   } \label{fig:density}
 \end{figure}
@@ -843,40 +810,26 @@ A similar analysis holds for the supergravity case.
 The analysis on $r$ in Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}) is consistent with the bound of Eq.~(\ref{eq:rBound}).
 The reason for the smallness of $r$ for Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}) and more generally for models with flat potentials can be traced to Eq.~(\ref{eq:Deltaphi}) and the condition $\Delta\phi < M_{Pl}$.
 
-However, Eq.~(\ref{eq:Deltaphi}) is not applicable to DBI-flation and k-flation~\cite{Garriga:1999vw}
+However, Eq.~(\ref{eq:Deltaphi}) is not applicable to DBI-flation and k-flation~\cite{Garriga:1999vw}.
 Here we need to look at the evolution of the density $\rho$ of the inflaton field as a function of e-foldings.
-\rr{Thus for the case when sound velocity $c_s \sim 1$, one can obtain the slow roll parameters in terms of density and
-its derivatives with respect to the number of e-foldings so that
-
-\begin{align}
-\epsilon_H&=-\frac{1}{2\rho} \frac{d\rho}{dN}\nonumber\\
-\eta_H&=  \frac{1}{\rho} \frac{d\rho}{dN}- \frac{d^2\rho}{dN^2}/\frac{d\rho}{dN}
-\end{align}
-Further, the enhancement factor $f_{eH}$ is given by 
-\begin{align}
-f_{eH}= M_{Pl}/\sqrt{2 \frac{\frac{d\rho}{dN}}{\rho} 
-- \frac{d^2\rho}{dN^2}/\frac{d\rho}{dN}}
-\end{align}
+Thus for the case when sound velocity $c_s \sim 1$, one can obtain the slow-roll parameters in terms of density and its derivatives with respect to the number of e-foldings so that
+\begin{equation}
+  \begin{aligned}
+    \epsilon_H &= -\frac{1}{2 \rho} \frac{d\rho}{dN}\,,\\
+    \eta_H &= \frac{1}{\rho} \frac{d\rho}{dN} - \frac{d^2\rho}{dN^2} / \frac{d\rho}{dN}\,.
+  \end{aligned}
+\end{equation}
+Further, the enhancement factor $f_{eH}$ is given by
+\begin{equation}
+  f_{eH} = M_{Pl} \left/ \sqrt{2 \frac{\frac{d\rho}{dN}}{\rho} - \left.\frac{d^2\rho}{dN^2} \middle/ \frac{d\rho}{dN}\right.}\right.\,.
+\end{equation}
 Similarly the spectral index $n_s$ and the ratio $r$ of the tensor to scalar power spectrum are given by
-\begin{align}
-n_s&= 1+ \frac{2}{\rho} \frac{d\rho}{dN}- \frac{d^2\rho}{dN^2}/\frac{d\rho}{dN} \nonumber\\
-r&= - \frac{8}{\rho} \frac{d\rho}{dN}\,.
-\label{eq:rFromDDensityr}
-\end{align}
-
-
-
-}
-% $r$ can be approximated as follows
-
-%
-
-%\begin{equation} \label{eq:rFromDDensityDN}
-%  r \approx 16 \epsilon_H
-%          = - 16 \frac{\dot H}{H^2}
-%          = - \frac{128 \sqrt{3} \dot\rho M_{Pl}}{\rho^{3 / 2}}
-%          = - \frac{128}{\rho} \frac{d\rho}{dN}\,.
-%\end{equation}
+\begin{equation} \label{eq:rFromDDensityDN}
+  \begin{aligned}
+    n_s &= 1 + \frac{2}{\rho} \frac{d\rho}{dN} - \left.\frac{d^2\rho}{dN^2} \middle/ \frac{d\rho}{dN}\right.\,,\\
+    r &= - \frac{8}{\rho} \frac{d\rho}{dN}\,.
+  \end{aligned}
+\end{equation}
 From the plot of $\rho / \rho_0$ as a function of $N - N_{\text{total}}$ one finds that $\frac{d\rho}{dN}$ is very small for the top panels of Fig.~(\ref{fig:density}) in the domain of horizon exit, i.e., $-60 < N - N_\text{total} < -50$ and leads to $r \sim O\left(10^{-4}\right)$.
 On the other hand for the DBI case $\frac{d\rho}{dN}$ is visibly much larger as can be seen by the bottom panel of Fig.~(\ref{fig:density}).
 This explains why $r$ is much larger for the DBI case than for the case where inflation is driven by the potential which is the case for the top panels of Fig.~(\ref{fig:density}).
@@ -901,7 +854,7 @@ We also show that the effective decay constant can be directly related to the sp
 The analysis presented in this work shows that in all the cases considered axion inflation consistent with the experimental data can be accomplished with the axion decay constant in the microscopic Lagrangian in the sub-Planckian domain in conformity with the Weak Gravity Conjecture.\\~\\~\\
 
 \textbf{Acknowledgments:}
-\rr{Conversations with James Halverson and Cody Long are acknowledged.}
+Conversations with James Halverson and Cody Long are acknowledged.
 This research was supported in part by the NSF Grant PHY-1620575.
 
 \clearpage

--- a/coherent-enhancement.tex
+++ b/coherent-enhancement.tex
@@ -1,4 +1,6 @@
-\documentclass[11pt]{article}
+
+    
+\documentclass[12pt]{article}
 \pdfoutput=1
 
 \usepackage{amsmath} % math
@@ -11,7 +13,7 @@
 \usepackage[numbers, sort & compress]{natbib} % cleanup citations
 \usepackage{parskip} % add vertical space between paragraphs
 \usepackage[section]{placeins} % keep figures inside their sections
-
+\newcommand{\rr}[1]{{\color{red}{#1}}}
 \author{
   Pran Nath\footnote{Email: p.nath@northeastern.edu}~\ and
   Maksim Piskunov\footnote{Email: m.piskunov@northeastern.edu}\\~\\
@@ -20,7 +22,8 @@
 }
 
 \title{
-  Enhancement of the Axion Decay Constant in Inflation and the Weak Gravity Conjecture
+  Enhancement 
+   of the Axion Decay Constant in Inflation and the Weak Gravity Conjecture
 }
 
 \begin{document}
@@ -29,24 +32,26 @@
 
 \textbf{Abstract:}
 Models of axion inflation based on a single cosine potential require the axion decay constant $f$ to be super-Planckian in size.
-However, $f > M_\text{P}$ is disfavored by the weak gravity conjecture (WGC).
+However, $f > M_{Pl}$ is disfavored by the weak gravity conjecture (WGC).
 It is then pertinent to ask if one can construct axion inflation models in conformity with WGC.
-In this work we assume that WGC holds for the microscopic Lagrangian so that $f < M_\text{P}$.
+In this work we assume that WGC holds for the microscopic Lagrangian so that $f < M_{Pl}$.
 However, inflation is controlled by an effective Lagrangian much below the Planck scale where the inflaton is an effective axionic field associated with an effective decay constant $f_e$ which could be very different from $f$.
-In this work we propose a coherent enhancement mechanism (CEM) for slow roll inflation controlled by flat potentials which can produce $f_e \gg M_\text{P}$ while $f < M_\text{P}$.
+In this work we propose a coherent enhancement mechanism (CEM) for slow roll inflation controlled by flat potentials which can produce $f_e \gg M_{Pl}$ while $f < M_{Pl}$.
 Here we consider a landscape of chiral fields charged under a $U\left(1\right)$ global shift symmetry and consider breaking of the $U\left(1\right)$ symmetry by instanton type symmetry breaking terms.
 In the broken phase there is one light pseudo-Nambu-Goldstone-Boson (pNGB) which acts as the inflaton.
-We show that with an appropriate choice of symmetry breaking terms the inflaton potential is a superposition of many cosines and the condition that they produce a flat potential allows one to enhance $f_e$ so that $f_e / M_\text{P} \gg 1$.
+We show that with an appropriate choice of symmetry breaking terms the inflaton potential is a superposition of many cosines and the condition that they produce a flat potential allows one to enhance $f_e$ so that $f_e / M_{Pl} \gg 1$.
 We discuss the utility of this mechanism for a variety of inflaton models originating in supersymmetry and supergravity.
 The coherent enhancement mechanism allows one to reduce an inflation model with an arbitrary potential to an effective model of natural inflation, i.e. with a single cosine, by expanding the potential near an inflationary point, and matching the expansion coefficients to those of natural inflation.
 We demonstrate that this approach can predict the number of e-foldings in a given inflation model without the need for numerical simulation.
-Further we show that the effective decay constant $f_e$ can be directly related to the spectral indices so that $f_e = M_\text{P} / \sqrt{1 - n_s - r / 4}$ where $n_s$ is the spectral index for curvature perturbations and $r$ is the ratio of the power spectrum of tensor perturbations and curvature perturbations.
-The current data on $n_s$ and $r$ constrains the effective axion decay constant so that $4.9 \leq f_e / M_\text{P} \leq 10.0$ at $95\%$ CL.
-Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 10 M_\text{P}$ in axion cosmology for any potential-based model which produces successful inflation.
-For the Dirac-Born-Infeld inflation and more generally k-flation, CEM is not applicable.
-Nonetheless in this case also we show that successful inflation can occur with $f < M_\text{P}$.
+Further we show that the effective decay constant $f_e$ can be directly related to the spectral indices so that $f_e = M_{Pl} / \sqrt{1 - n_s - r / 4}$ where $n_s$ is the spectral index for curvature perturbations and $r$ is the ratio of the power spectrum of tensor perturbations and curvature perturbations.
+The current data on $n_s$ and $r$ constrains the effective axion decay constant so that $4.9 \leq f_e / M_{Pl} \leq 10.0$ at $95\%$ CL.
+Thus an important result of the analysis is that the effective axion decay constant has an upper limit of $\sim 10 M_{Pl}$ in axion cosmology for any potential-based model which produces successful inflation.
+For the Dirac-Born-Infeld inflation
+ and more generally k-flation
+ CEM is not applicable. 
+ Nonetheless in this case also we show that successful inflation can occur with $f < M_\text{P}$. 
 Further, one can define a more general effective axion decay constant valid for inflation controlled either by flat potentials or by k-flation.
-In the models considered in this work, all the moduli are stabilized and the inflationary model in each case is consistent with astrophysical observations with $f_e > M_\text{P}$ and the axion decay constant of the microscopic theory satisfies $f < M_\text{P}$ consistent with the weak gravity conjecture.
+In the models considered in this work, all the moduli are stabilized and the inflationary model in each case is consistent with astrophysical observations with $f_e > M_{Pl}$ and the axion decay constant of the microscopic theory satisfies $f < M_{Pl}$ consistent with the weak gravity conjecture.
 \footnote{Source code: \url{https://github.com/maxitg/coherent-enhancement}}
 \newpage
 
@@ -56,10 +61,10 @@ the flatness problem, the horizon problem, and the monopole problem are resolved
 Quantum fluctuations at the time of horizon exit carry significant information regarding specifics of the inflationary model~\cite{Mukhanov:1981xt, Hawking:1982cz, Starobinsky:1982ee, Guth:1982ec, Bardeen:1983qw, Cheung:2007st} which can be extracted from cosmic microwave background (CMB) radiation anisotropy.
 The data from the Planck experiment~\cite{Akrami:2018vks, Akrami:2018odb, Array:2015xqh} has helped constrain inflation models excluding some and narrowing down the parameter space of others.
 One such model is so-called natural inflation based on a $U(1)$ shift symmetry which is described by a simple potential~\cite{Freese:1990rb, Adams:1992bn} $V\left(a\right) = \Lambda^4 \left(1 - \cos\left(\frac{b}{f}\right)\right)$, where $a$ is the axion field and $f$ is the axion decay constant.
-In this case, consistency with Planck data requires the axion decay constant to be significantly greater than the Planck mass $M_\text{P}$.
+In this case, consistency with Planck data requires the axion decay constant to be significantly greater than the Planck mass $M_{Pl}$.
 However, an axion decay constant larger than the Planck mass is undesirable since a global symmetry is not preserved by quantum gravity unless it has a gauge origin.
-Additionally string theory prefers the axion decay constant to lie below $M_\text{P}$~\cite{Banks:2003sx, Svrcek:2006yi}.
-These results are codified in WGC which requires $f < M_\text{P}$.
+Additionally string theory prefers the axion decay constant to lie below $M_{Pl}$~\cite{Banks:2003sx, Svrcek:2006yi}.
+These results are codified in WGC which requires $f < M_{Pl}$.
 It is then relevant to ask if in general axion inflation models can be constructed consistent with the WGC constraint.
 
 In this work we show that one can in fact construct axionic inflation models consistent with the WGC constraint.
@@ -69,10 +74,10 @@ Such a situation occurs if one considers a landscape of chiral fields each of wh
 In this case the inflaton is an effective axion field which is a linear combination of many axion fields and is associated with an effective axion decay constant which can be very different from the axion decay constant of the microscopic theory.
 Several suggestions along this line exist such as the alignment mechanism~\cite{Kim:2004rp, Long:2014dta}.
 We will discuss this suggestion in more detail in section \ref{sec:Alignment}.
-In this work we propose a new mechanism, i.e., the coherent enhancement mechanism slow roll inflation governed by flat potentials for constructing models of axionic inflation where the effective axion decay constant $f_e$ can be much larger than $M_\text{P}$ needed for generating successful inflation while $f < M_\text{P}$ consistent with WGC~\cite{Nath:2017ihp}.
+In this work we propose a new mechanism, i.e., the coherent enhancement mechanism slow roll inflation governed by flat potentials for constructing models of axionic inflation where the effective axion decay constant $f_e$ can be much larger than $M_{Pl}$ needed for generating successful inflation while $f < M_{Pl}$ consistent with WGC~\cite{Nath:2017ihp}.
 The proposed mechanism applies to supersymmetric and supergravity theories (for a review of inflation in supersymmetric theories see, e.g.,~\cite{Nath:2016qzm}).
 For Dirac-Born-Infeld-infation CEM does not work.
-However, it is shown that DBI can produce successful inflation with $f < M_\text{P}$.
+However, it is shown that DBI can produce successful inflation with $f < M_{Pl}$.
 Thus an analysis within these models shows that one can obtain spectral indices as well as the ratio of the tensor to the scalar power spectrum consistent with the Planck data~\cite{Akrami:2018vks, Akrami:2018odb, Array:2015xqh} and consistent with WGC.
 
 The outline of the rest of the paper is as follows.
@@ -88,21 +93,22 @@ Conclusions are given in section \ref{sec:Conclusion}.
 Some relevant papers related to this work can be found in \cite{BlancoPillado:2006he, Conlon:2005jm, Ben-Dayan:2014lca, Gao:2014uha}.
 
 \section{The weak gravity conjecture and axion inflation \label{sec:WeakGravityConjecture}}
-In its simplest form the weak gravity conjecture (WGC) considers the coupling of an abelian gauge field with gravity and states that this system must contain a particle of charge $q$ and mass $m$ so that~\cite{ArkaniHamed:2006dz} $\frac{q}{m} > \frac{1}{M_\text{P}}$.
+In its simplest form the weak gravity conjecture (WGC) considers the coupling of an abelian gauge field with gravity and states that this system must contain a particle of charge $q$ and mass $m$ so that~\cite{ArkaniHamed:2006dz} $\frac{q}{m} > \frac{1}{M_{Pl}}$, 
+where $M_{Pl}$ is the reduce Planck mass defined by $M_{Pl}= (8\pi G_N)^{-1/2}$ and $G_N$ is Newton's constant. 
 The existence of such a particle is needed to carry away the charge of a black hole to avoid the remnant problem when the black hole evaporates due to Hawking radiation.
 The above constraint is found to be consistent with string theory and thus one might argue that consistent theories of quantum gravity obey the weak gravity conjecture.
 Specifically, for example, one cannot let the charge $q$ become arbitrarily small since in that case in the limit one will have a continuous global symmetry which is forbidden by strings.
 So far the analysis concerns just the abelian gauge theories coupling with gravity.
 However, there is a generalized WGC which has implications for axions and for axionic inflation.
 
-The generalized WGC constraints the axion decay constant so that $f \leq M_\text{P} / S$ where $S$ is the instanton action~\cite{Brown:2015iha, Brown:2015lia, Heidenreich:2015wga}.
-String theory requires $S \geq 1$, so that the theory is in the perturbative domain, which gives $f \leq M_\text{P}$.
+The generalized WGC constraints the axion decay constant so that $f \leq M_{Pl} / S$ where $S$ is the instanton action~\cite{Brown:2015iha, Brown:2015lia, Heidenreich:2015wga}.
+String theory requires $S \geq 1$, so that the theory is in the perturbative domain, which gives $f \leq M_{Pl}$.
 We note in passing that the constraints of WGC for axions are more indirectly arrived at relative to the original WGC.
 However, there is support for the generalized conjecture as it relates to axions.
 Thus even before WGC, Bank et al.~\cite{Banks:2003sx} analyzed a number of periodic fields in string theory for various string vacua and found that an axion decay constant larger than the Planck mass was undesirable.
 Also analyses for a wide variety of axions in strings estimate the axion decay constant to lie in the range $\left(10^{16} - 10^{18}\right) \text{GeV}$~\cite{Svrcek:2006yi}.
 
-WGC poses a problem for natural inflation since natural inflation requires $f > 5 M_\text{P}$ in apparent contradiction with WGC.
+WGC poses a problem for natural inflation since natural inflation requires $f > 5 M_{Pl}$ in apparent contradiction with WGC.
 However, here we need to keep in mind that the WGC constraint on the axion decay constant applies to the microscopic theory.
 An effective theory below the Planck scale is not necessarily subject to that constraint.
 More specifically, the inflaton need not be a primary field in the microscopic theory but rather an effective field such as a linear combination of the primary field in the domain where the $U\left(1\right)$ global symmetry is spontaneously broken and the inflaton possesses an effective potential generated solely from such breaking.
@@ -113,11 +119,11 @@ There is a significant amount of literature associated with this topic, see, e.g
 
 In the this work we propose an alternative mechanism for the enhancement of the effective decay constant associated with inflation.
 The mechanism rests on coherence among several symmetry breaking terms in the inflaton potential and for that reason we call this mechanism the coherent enhancement mechanism.
-With this mechanism one can achieve $f_e > 5 M_\text{P}$ and inflation consistent with the Planck data, while the axion decay constant $f$ in the microscopic theory satisfies $f < M_\text{P}$.
+With this mechanism one can achieve $f_e > 5 M_{Pl}$ and inflation consistent with the Planck data, while the axion decay constant $f$ in the microscopic theory satisfies $f < M_{Pl}$.
 In section \ref{sec:Alignment} we discuss the alignment mechanism while in section \ref{sec:CoherentEnhancement} we discuss the proposed coherent enhancement mechanism.
 
 \section{Alignment mechanism \label{sec:Alignment}}
-An interesting suggestion to realize $f_e > M_\text{P}$ while $f < M_\text{P}$ is to use two axions and the alignment mechanism~\cite{Kim:2004rp} to achieve a flat direction.
+An interesting suggestion to realize $f_e > M_{Pl}$ while $f < M_{Pl}$ is to use two axions and the alignment mechanism~\cite{Kim:2004rp} to achieve a flat direction.
 For a model with two axions $\phi_1$ and $\phi_2$ one considers a potential
 \begin{equation} \label{eq:alignmentPotential}
   V(\phi)
@@ -130,9 +136,10 @@ To have a flat direction in the field space one imposes the constraint
 \end{equation}
 A small correction to the constraint gives inflaton a mass and produces an effective axion decay constant larger that $f$.
 For example, if one considers $f_1 = f_2 = f_3 = f$, $f_4 = f\left(1 + \delta\right)$, and $\Lambda_1 = \Lambda_2$, the inflaton field in this case will have an effective axion decay constant $f_e \sim f / \delta$.
-However, achieving solutions with stabilized moduli appears difficult using this mechanism in string models~\cite{Long:2014dta}.
-Below we discuss the coherent enhancement mechanism that can lead to an effective axion decay constant that controls inflation and is much larger than the true decay constant.
-Further, we exhibit this phenomenon in models based on supersymmetry and supergravity, and in Dirac-Born-Infeld models.
+\rr{(For a discussion on implementing the mechanism with  stabilized moduli in string models see, e.g.,~\cite{Long:2014dta}.)}
+Below we discuss the coherent enhancement mechanism (CEM) that can lead to an effective axion decay constant that controls inflation and is much larger than the true decay constant.
+\rr{Further, we exhibit this phenomenon in models based on supersymmetry and supergravity. Later we discuss the
+DBI-enhacement which enters in Dirac-Born-Infeld inflationary models.}
 
 \section{General analysis of coherent enhancement mechanism \label{sec:CoherentEnhancement}}
 As mentioned in section \ref{sec:Introduction}, coherent enhancement mechanism works for slow roll inflation arising from a flat potential.
@@ -178,16 +185,16 @@ Now, identifying the expansion coefficients in Eq.~(\ref{eq:naturalInflationSeri
     {{V^\prime}^2\left(\phi_0\right) - V\left(\phi_0\right) V^{\prime\prime}\left(\phi_0\right)}\,.
 \end{equation}
 Here, we are mostly interested in Eq.~(\ref{eq:feFromPotential}), which gives the effective axion decay constant for the potential $V\left(\phi\right)$ near $\phi = \phi_0$.
-Due to the second flatness condition, $\left|\eta\right| = M_\text{P}^2 \left|V_e^{\prime\prime} / V_e\right| = M_\text{P}^2 / f_e^2 \ll 1$, natural inflation can only generate experimentally consistent observables when $f_e \gg M_\text{P}$.
+Due to the second flatness condition, $\left|\eta\right| = M_{Pl}^2 \left|V_e^{\prime\prime} / V_e\right| = M_{Pl}^2 / f_e^2 \ll 1$, natural inflation can only generate experimentally consistent observables when $f_e \gg M_{Pl}$.
 However, as discussed already the true axion decay constant larger than one is undesirable from considerations of quantum gravity and string theory \cite{Kallosh:1995hi, Banks:2003sx}.
 Coherent Enhancement provides a solution in that the true axion decay constant can be smaller than one while the effective axion decay constant is larger or even much larger than one.
 
 Finally, it is also possible to express the effective decay constant in terms of slow-roll inflation parameters $\epsilon$ and $\eta$ defined as
 \begin{equation} \label{eq:epsEtaFromPotential}
   \epsilon =
-    \frac{M_\text{P}^2}{2}
+    \frac{M_{Pl}^2}{2}
     \left(\frac{V^\prime\left(\phi_0\right)}{V\left(\phi_0\right)}\right)^2\,,
-  ~~~ \eta = M_\text{P}^2 \frac{V^{\prime\prime}\left(\phi_0\right)}{V\left(\phi_0\right)}\,.
+  ~~~ \eta = M_{Pl}^2 \frac{V^{\prime\prime}\left(\phi_0\right)}{V\left(\phi_0\right)}\,.
 \end{equation}
 
 By combining these with Eqs.~(\ref{eq:lambdaFromPotential}, \ref{eq:feFromPotential}, \ref{eq:fieldInitialFromPotential}), we obtain
@@ -195,7 +202,7 @@ By combining these with Eqs.~(\ref{eq:lambdaFromPotential}, \ref{eq:feFromPotent
   \label{eq:lambdaSlowRoll}
   \Lambda &= V\left(\phi_0\right) \frac{2 \epsilon - \eta}{2 \epsilon - 2 \eta}\,,\\
   \label{eq:feSlowRoll}
-  f_e &= \frac{M_\text{P}}{\sqrt{2 \left(\epsilon - \eta\right)}}\,,\\
+  f_e &= \frac{M_{Pl}}{\sqrt{2 \left(\epsilon - \eta\right)}}\,,\\
   \label{eq:fieldInitialSlowRoll}
   \cos\left(\frac{\varphi_0}{f_e}\right) &= \frac{\eta}{2 \epsilon - \eta}\,.
 \end{align}
@@ -208,7 +215,7 @@ The spectral indices $n_s$ and $n_t$ are related to the inflationary parameters 
 \end{equation}
 We can thus eliminate $\eta$ and $\epsilon$ in favor of $n_s$ and $r$ and get
 \begin{equation} \label{eq:feSpectralIndices}
-  f_e = \frac{M_\text{P}}{\sqrt{1 - n_s - r / 4}}\,.
+  f_e = \frac{M_{Pl}}{\sqrt{1 - n_s - r / 4}}\,.
 \end{equation}
 The current experimental limits from Planck experiment at $k_0 = 0.05\,{\rm Mpc}^{-1}$ are as follows~\cite{Akrami:2018vks, Akrami:2018odb, Array:2015xqh}
 \begin{equation} \label{data}
@@ -220,7 +227,7 @@ The current experimental limits from Planck experiment at $k_0 = 0.05\,{\rm Mpc}
 while $n_t\left(k_0\right)$ is currently not constrained.
 Using this data we find model-independent bounds on the effective axionic decay constant so that
 \begin{equation} \label{eq:feExperimentalConstraint}
-  4.9 \leq f_e / M_\text{P} \leq 10.0\, \left(95\%\, {\rm CL}\right)\,.
+  4.9 \leq f_e / M_{Pl} \leq 10.0\, \left(95\%\, {\rm CL}\right)\,.
 \end{equation}
 
 Next, we discuss the coherent enhancement mechanism arising from a superposition of cosine functions and show how the effective axion decay constant becomes super-Planckian even though the true decay constant is sub-Planckian.
@@ -247,21 +254,22 @@ Specifically, we can define dynamic slow-roll parameters
   ~~~ \eta_H = -\frac{\dot{\epsilon_H}}{\epsilon_H H}\,,
   ~~~ \sigma_H = -\frac{1}{H} \frac{d}{dt} \ln c_s\,,
 \end{equation}
-where $c_s$ is the speed of sound in the medium.
+where $c_s$ is the speed of sound in the medium \rr{where $c_s^2= p_{,\beta}/\rho_{,\eta}$, $\beta= \dot \phi^2$
+where $p$ is the pressure and $\rho$ the density. }
 In this case spectral indices are given by~\cite{Garriga:1999vw, Spalinski:2007qy}
 \begin{equation}
       n_s = 1 - 2 \epsilon_H + \eta_H + \sigma_H,
   ~~~ n_t = - 2\epsilon_H\,.
 \end{equation}
 
-For the case when the velocity dependence of the parameters is relatively small one has
+For the case when the  dependence \rr{on sound speed $c_s$} of the parameters is relatively small one has
 \begin{equation} \label{eq:slowRollParametersDynamicFromStatic}
   \epsilon_H = \epsilon\,,
   ~~~ \eta_H = -2 \eta + 4 \epsilon\,,
 \end{equation}
 in which case Eq.~(\ref{eq:feSlowRoll}) can be rewritten as
 \begin{equation} \label{eq:feFromDynamicSlowRollParameters}
-  f_{eH} = \frac{M_\text{P}}{\sqrt{\eta_H - 2 \epsilon_H}}\,.
+  f_{eH} = \frac{M_{Pl}}{\sqrt{\eta_H - 2 \epsilon_H}}\,.
 \end{equation}
 
 We will show using numerical simulations that $f_e \approx f_{eH}$ for the cases of global supersymmetry and supergravity.
@@ -318,6 +326,28 @@ Including $W_{sb}$ the axionic potential can be written in the form
 \end{equation}
 where $V_\text{slow}\left(b_-\right)$ which depends only on $b_-$ enters in slow roll and is relevant for inflation.
 
+\begin{figure}
+  \centering
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/supersymmetry_ns_r.pdf}
+  \end{subfigure}
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/supersymmetry_f_fStatic.pdf}
+  \end{subfigure}
+  \begin{subfigure}{0.45 \textwidth}
+    \includegraphics[width = \textwidth]{figures/supersymmetry_potentialRange.pdf}
+  \end{subfigure}
+  \caption{\protect\input{figures/supersymmetry.txt}
+    Top left panel shows tensor-to-scalar ratio vs scalar spectral index.
+    Blue region encloses the parameter points consistent with Planck 2018 TT,TE,EE+lowE+lensing+BK14+BAO data at $95\%$ CL.
+    Top right panel exhibits the coherent enhancement of the decay constant.
+    The bottom panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
+    Note that because the field is normalized by $f$ and because $G_5$ is fine-tuned, potentials for all considered input parameters look almost identical.
+    Inflation occurs in the flat region of the potential near $b_- / f \approx 3$.
+    Here the field transversal during inflation is $\Delta b_- < f \le M_{Pl}$.
+    The analysis shows that axion inflation by the parameter points in the blue region is consistent with WGC as exhibited by the top right panel.
+  } \label{fig:supersymmetry}
+\end{figure}
 Note, the values of the parameters $\mu$ and $\lambda / M$ determine the stability point $f$.
 We can equivalently however fix $f$ and solve for $\lambda / M$ in terms of $\mu$ and $f$.
 It turns out $\mu$ only appears in $V_\text{fast}$, but not in $V_\text{slow}$, for which an explicit form is given by
@@ -348,28 +378,28 @@ Using the above assumptions the potential of Eq.~(\ref{eq:supersymmetry:VslowGen
   \end{aligned}
 \end{equation}
 
-\begin{figure}
-  \centering
-  \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/supersymmetry_ns_r.pdf}
-  \end{subfigure}
-  \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/supersymmetry_f_fStatic.pdf}
-  \end{subfigure}
-  \begin{subfigure}{0.45 \textwidth}
-    \includegraphics[width = \textwidth]{figures/supersymmetry_potentialRange.pdf}
-  \end{subfigure}
-  \caption{\protect\input{figures/supersymmetry.txt}
-    Top left panel shows tensor-to-scalar ratio vs scalar spectral index.
-    Blue region encloses the parameter points consistent with Planck 2018 TT,TE,EE+lowE+lensing+BK14+BAO data at $95\%$ CL.
-    Top right panel exhibits the coherent enhancement of the decay constant.
-    The bottom panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
-    Note that because the field is normalized by $f$ and because $G_5$ is fine-tuned, potentials for all considered input parameters look almost identical.
-    Inflation occurs in the flat region of the potential near $b_- / f \approx 3$.
-    Here the field transversal during inflation is $\Delta b_- < f \le M_\text{P}$.
-    The analysis shows that axion inflation by the parameter points in the blue region is consistent with WGC as exhibited by the top right panel.
-  } \label{fig:supersymmetry}
-\end{figure}
+%\begin{figure}
+%  \centering
+%  \begin{subfigure}{0.45 \textwidth}
+%    \includegraphics[width = \textwidth]{figures/supersymmetry_ns_r.pdf}
+%  \end{subfigure}
+%  \begin{subfigure}{0.45 \textwidth}
+%    \includegraphics[width = \textwidth]{figures/supersymmetry_f_fStatic.pdf}
+%  \end{subfigure}
+%  \begin{subfigure}{0.45 \textwidth}
+%    \includegraphics[width = \textwidth]{figures/supersymmetry_potentialRange.pdf}
+%  \end{subfigure}
+%  \caption{\protect\input{figures/supersymmetry.txt}
+%    Top left panel shows tensor-to-scalar ratio vs scalar spectral index.
+%    Blue region encloses the parameter points consistent with Planck 2018 TT,TE,EE+lowE+lensing+BK14+BAO data at $95\%$ CL.
+%    Top right panel exhibits the coherent enhancement of the decay constant.
+%    The bottom panel shows the superimposed slow-roll potentials~Eq.(\ref{eq:supersymmetry:Vslow}) as functions of $b_-$ for all values of $G_5$ considered.
+%    Note that because the field is normalized by $f$ and because $G_5$ is fine-tuned, potentials for all considered input parameters look almost identical.
+%    Inflation occurs in the flat region of the potential near $b_- / f \approx 3$.
+%    Here the field transversal during inflation is $\Delta b_- < f \le M_{Pl}$.
+%    The analysis shows that axion inflation by the parameter points in the blue region is consistent with WGC as exhibited by the top right panel.
+%  } \label{fig:supersymmetry}
+%\end{figure}
 
 Here the superposition of several cosines produces local flatness where slow roll can occur.
 In order to verify consistency with experiment and evaluate $f_e$, we use Inflation Simulator\footnote{\url{https://github.com/maxitg/InflationSimulator}}.
@@ -379,22 +409,26 @@ We set initial field velocity $\dot b_{-, \text{init}} = 0$, and check that at l
 Finally, if we have sufficient number of e-foldings, we compute the tensor-to-scalar ratio $r$, and the scalar spectral index $n_s$ at horizon exit (i.e., $N_\text{pivot}$ e-foldings before the end of inflation) using Eqs.~(\ref{eq:slowRollParametersDynamic}, \ref{eq:slowRollParametersDynamicFromStatic}, \ref{eq:observablesSlowRoll}), and check if they are consistent with experimental constraints~\cite{Akrami:2018odb}.
 If so, we evaluate $f_e$ and $f_{eH}$ at horizon exit using Eqs.~(\ref{eq:feFromPotential}, \ref{eq:feFromDynamicSlowRollParameters}).
 The results of this process can be seen on Fig.~(\ref{fig:supersymmetry}).
-One can see that even though the true decay constant $f$ is below $M_\text{P}$, the effective $f_e \approx f_{eH}$ always satisfy constraint \ref{eq:feExperimentalConstraint}.
+One can see that even though the true decay constant $f$ is below $M_{Pl}$, the effective $f_e \approx f_{eH}$ always satisfy constraint \ref{eq:feExperimentalConstraint}.
 We find the relative difference between two effective decay constants $\left|f_e - f_{eH}\right| / f_e \le \protect\input{figures/supersymmetryfRelativeDifferenceMax.txt}$.
 We note that fine tuning of $G_5$ is required to achieve coherent enhancement and experimentally-consistent inflation.
-Further the analysis of Fig.~(\ref{fig:supersymmetry}) shows that CEM is operative and $f_e / M_\text{P} \gg 1$ is achieved while $f < M_\text{P}$ consistent with WGC.
+Further the analysis of Fig.~(\ref{fig:supersymmetry}) shows that CEM is operative and $f_e / M_{Pl} \gg 1$ is achieved while $f < M_{Pl}$ consistent with WGC.
+
+
+
+
 
 \section{Supergravity \label{sec:Supergravity}}
 Next we test CEM for supergravity where the scalar potential has the form~\cite{Chamseddine:1982jx, Cremmer:1982en}
 \begin{equation} \label{eq:supergravity:potential}
-  V = e^{K / M_\text{P}^2} \left[
-    D_i W K^{-1}_{ij^*} D_{j^*} W^* - \frac{3}{M_\text{P}^2} \left|W\right|^2
+  V = e^{K / M_{Pl}^2} \left[
+    D_i W K^{-1}_{ij^*} D_{j^*} W^* - \frac{3}{M_{Pl}^2} \left|W\right|^2
   \right] + V_D\,,
 \end{equation}
 where $K$ is the K\"ahler potential, $W$ as before is the superpotential, and $D_i W$ is defined by
 \begin{equation} \label{eq:supergravity:DW}
   D_i W = \frac{\partial W}{\partial \phi_i}
-        + \frac{1}{M_\text{P}^2} \frac{\partial K}{\partial \phi_i} W\,.
+        + \frac{1}{M_{Pl}^2} \frac{\partial K}{\partial \phi_i} W\,.
 \end{equation}
 $V_D$, which is the $D$-term of the potential, will play no role in our analysis and will be dropped from here on.
 In order to avoid the so-called $\eta$-problem of supergravity we choose the K\"ahler potential to be of the form
@@ -448,16 +482,16 @@ In this case the slow-roll part of the potential which involves only the field $
 \begin{equation} \label{eq:supergravity:Vslow}
   \begin{aligned}
     V\left(b_-\right) =
-      & 4 M_\text{P}^4 e^{2 f^2 / M_\text{P}^2} \sum_{n = 1}^q \sum_{m = 1}^q
-        e^{\gamma_n + \gamma_m} \frac{A_n A_m}{M_\text{P}^6}\\
+      & 4 M_{Pl}^4 e^{2 f^2 / M_{Pl}^2} \sum_{n = 1}^q \sum_{m = 1}^q
+        e^{\gamma_n + \gamma_m} \frac{A_n A_m}{M_{Pl}^6}\\
         &{} \times \left[
-          \gamma_n \gamma_m \frac{M_\text{P}^2}{f^2} \left(
+          \gamma_n \gamma_m \frac{M_{Pl}^2}{f^2} \left(
               1
             - \cos\left(\gamma_n \frac{b_-}{\sqrt{2} f}\right)
             - \cos\left(\gamma_m \frac{b_-}{\sqrt{2} f}\right)
             + \cos\left(\left(\gamma_n - \gamma_m\right) \frac{b_-}{\sqrt{2} f}\right)
           \right)\right.\\
-          &~~~~~~ + \left(2 \gamma_n + 2 \gamma_m - 3 + 4 \frac{f^2}{M_\text{P}^2}\right) \left(
+          &~~~~~~ + \left(2 \gamma_n + 2 \gamma_m - 3 + 4 \frac{f^2}{M_{Pl}^2}\right) \left(
               1
             - \cos\left(\gamma_n \frac{b_-}{\sqrt{2} f}\right)
             - \cos\left(\gamma_m \frac{b_-}{\sqrt{2} f}\right)\right.\\
@@ -472,47 +506,47 @@ For our analysis we take $\gamma_n = n$ and $q = 3$, which is the minimal value 
 In that case the above potential consists of a superposition of six cosines so that
 \begin{equation} \label{eq:supergravity:Vslow3}
   V\left(b_-\right)
-    = M_\text{P}^4 e^{2 f^2 / M_\text{P}^2} \sum_{k = 1}^6 C_k \left(1 - \cos\left(\frac{k b_-}{\sqrt{2} f}\right)\right)\,,
+    = M_{Pl}^4 e^{2 f^2 / M_{Pl}^2} \sum_{k = 1}^6 C_k \left(1 - \cos\left(\frac{k b_-}{\sqrt{2} f}\right)\right)\,,
 \end{equation}
 where $C_k$ are given by
 \begin{equation} \label{eq:supergravity:Vslow3Coefficients}
   \begin{aligned}
     C_1 &=   4 \left(
-        2 e^2 \left(   \frac{M_\text{P}^2}{f^2} + 1 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_1^2  }{M_\text{P}^6}
-      +   e^3 \left(                              3 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_1 A_2}{M_\text{P}^6}\right.\\
+        2 e^2 \left(   \frac{M_{Pl}^2}{f^2} + 1 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1^2  }{M_{Pl}^6}
+      +   e^3 \left(                              3 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_2}{M_{Pl}^6}\right.\\
       &~~~~~~ \left.{}
-      + 2 e^4 \left( 3 \frac{M_\text{P}^2}{f^2} + 5 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_1 A_3}{M_\text{P}^6}
-      -   e^5 \left(12 \frac{M_\text{P}^2}{f^2} + 7 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_2 A_3}{M_\text{P}^6}
+      + 2 e^4 \left( 3 \frac{M_{Pl}^2}{f^2} + 5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_3}{M_{Pl}^6}
+      -   e^5 \left(12 \frac{M_{Pl}^2}{f^2} + 7 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2 A_3}{M_{Pl}^6}
     \right)\,,\\
     C_2 &=   2 \left(
-      -   e^2 \left(                              1 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_1^2  }{M_\text{P}^6}
-      + 4 e^3 \left( 2 \frac{M_\text{P}^2}{f^2} + 3 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_1 A_2}{M_\text{P}^6}\right.\\
+      -   e^2 \left(                              1 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1^2  }{M_{Pl}^6}
+      + 4 e^3 \left( 2 \frac{M_{Pl}^2}{f^2} + 3 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_2}{M_{Pl}^6}\right.\\
       &~~~~~~ \left.{}
-      + 4 e^4 \left( 4 \frac{M_\text{P}^2}{f^2} + 5 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_2^2  }{M_\text{P}^6}
-      - 2 e^4 \left( 6 \frac{M_\text{P}^2}{f^2} + 5 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_1 A_3}{M_\text{P}^6}\right.\\
+      + 4 e^4 \left( 4 \frac{M_{Pl}^2}{f^2} + 5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2^2  }{M_{Pl}^6}
+      - 2 e^4 \left( 6 \frac{M_{Pl}^2}{f^2} + 5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_3}{M_{Pl}^6}\right.\\
       &~~~~~~ \left.{}
-      + 4 e^5 \left( 6 \frac{M_\text{P}^2}{f^2} + 7 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_2 A_3}{M_\text{P}^6}
+      + 4 e^5 \left( 6 \frac{M_{Pl}^2}{f^2} + 7 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2 A_3}{M_{Pl}^6}
     \right)\,,\\
     C_3 &=   4 \left(
-      -   e^3 \left(                              3 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_1 A_2}{M_\text{P}^6}
-      + 2 e^4 \left( 3 \frac{M_\text{P}^2}{f^2} + 5 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_1 A_3}{M_\text{P}^6}\right.\\
+      -   e^3 \left(                              3 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_2}{M_{Pl}^6}
+      + 2 e^4 \left( 3 \frac{M_{Pl}^2}{f^2} + 5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_3}{M_{Pl}^6}\right.\\
       &~~~~~~ \left.{}
-      + 2 e^5 \left( 6 \frac{M_\text{P}^2}{f^2} + 7 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_2 A_3}{M_\text{P}^6}
-      + 2 e^6 \left( 9 \frac{M_\text{P}^2}{f^2} + 9 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_3^2  }{M_\text{P}^6}
+      + 2 e^5 \left( 6 \frac{M_{Pl}^2}{f^2} + 7 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2 A_3}{M_{Pl}^6}
+      + 2 e^6 \left( 9 \frac{M_{Pl}^2}{f^2} + 9 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_3^2  }{M_{Pl}^6}
     \right)\,,\\
     C_4 &=   2 \left(
-      - 2 e^4 \left(                              5 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_1 A_3}{M_\text{P}^6}
-      -   e^4 \left(                              5 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_2^2  }{M_\text{P}^6}
+      - 2 e^4 \left(                              5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_1 A_3}{M_{Pl}^6}
+      -   e^4 \left(                              5 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2^2  }{M_{Pl}^6}
     \right)\,,\\
     C_5 &= - 4
-          e^5 \left(                              7 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_2 A_3}{M_\text{P}^6}\,,\\
+          e^5 \left(                              7 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_2 A_3}{M_{Pl}^6}\,,\\
     C_6 &= - 2
-          e^6 \left(                              9 + 4 \frac{f^2}{M_\text{P}^2}\right) \frac{A_3^2  }{M_\text{P}^6}\,.
+          e^6 \left(                              9 + 4 \frac{f^2}{M_{Pl}^2}\right) \frac{A_3^2  }{M_{Pl}^6}\,.
   \end{aligned}
 \end{equation}
 As in the global supersymmetry case of section \ref{sec:Supersymmetry} here also local regions of flatness in the potential appear due to overlaps of several cosines, slow roll can occur and CEM is operative.
 Simulation results for this potential are similar to the global supersymmetry model and are shown on Fig.~(\ref{fig:supergravity}).
-Further one finds that there exist regions of the parameter space where $f_e \gg M_\text{P}$ while $f < M_\text{P}$ consistent with WGC.
+Further one finds that there exist regions of the parameter space where $f_e \gg M_{Pl}$ while $f < M_{Pl}$ consistent with WGC.
 In this model, we find $\left|f_e - f_{eH}\right| / f_e \le \protect\input{figures/supergravityfRelativeDifferenceMax.txt}$.
 
 \begin{figure}
@@ -529,7 +563,7 @@ In this model, we find $\left|f_e - f_{eH}\right| / f_e \le \protect\input{figur
   \caption{\protect\input{figures/supergravity.txt}
     Top left panel: Plot of $r$ vs $n_s$.
     The blue region contains parameter points that lie in the experimentally allowed range of $r$ and $n_s$.
-    Top right panel: A plot of the effective axion decay constant $f_e / M_\text{P}$ vs $f / M_\text{P}$ for the parameter points that lie in the blue region in the left panel.
+    Top right panel: A plot of the effective axion decay constant $f_e / M_{Pl}$ vs $f / M_{Pl}$ for the parameter points that lie in the blue region in the left panel.
     Bottom panel: Plot of $V / V_\text{max}$ vs $b_- / f$ for the parameter points that lie in the blue region in the top left panel.
     As in the global supersymmetry analysis of Fig.~(\ref{fig:supersymmetry}) the supergravity analysis here shows that axion inflation by the parameter points in the blue region is consistent with WGC as exhibited by the top right panel.
   } \label{fig:supergravity}
@@ -538,9 +572,9 @@ In this model, we find $\left|f_e - f_{eH}\right| / f_e \le \protect\input{figur
 \section{Dirac-Born-Infeld (DBI) \label{sec:DBI}}
 In sections \ref{sec:Supersymmetry} and \ref{sec:Supergravity} we discussed applications of CEM which accomplishes successful axion inflation in conformity with the current cosmological data and consistent with WGC.
 As mentioned in section \ref{sec:Introduction} CEM works only for models where slow roll is governed by flat potentials.
-This, however, is not the case for DBI-inflation.
+This, however, is not the case for DBI-flation.
 Here the entire Lagrangian enters in slow roll and CEM is not applicable.
-Nonetheless we will show in this section that axionic DBI-inflation allows for successful inflation consistent with cosmological data and consistent with WGC.
+Nonetheless we will show in this section that axionic DBI-flation allows for successful inflation consistent with cosmological data and consistent with WGC.
 We will work within the framework of supersymmetric DBI actions which have been investigated by a number of authors (see, e.g.,~\cite{Nath:2018xxe, Khoury:2010gb, Khoury:2011da, Baumann:2011nk, Baumann:2011nm, Rocek:1997hi, Tseytlin:1999dj, Ito:2007hy, Billo:2008sp, Sasaki:2012ka, Aoki:2016tod}.
 Inflation in a single field DBI has discussed in~\cite{Sasaki:2012ka} and for the case of two fields in~\cite{Nath:2018xxe}.
 Here we discuss the coherent enhancement mechanism in the context of the two fields.
@@ -743,7 +777,7 @@ We then select parameter choices than produced at least $N_\text{pivot}$ number 
     Top left panel is a plot of $r$ which is the tensor to scalar power spectrum vs the scalar spectral index $n_s$.
     Top right panel shows the non-Gaussianity parameter $f_{NL}^\text{equil}$ as a function of $\alpha_1$ (for a discussion of $f_{NL}^\text{equil}$ see ~\cite{Nath:2018xxe}).
     Bottom panel is a plot of $f_{eH}$ vs $f$ where $f_{eH}$ is defined by Eq.~(\ref{eq:feFromDynamicSlowRollParameters}).
-    We note that all the parameter points in the blue of the top left panel have $f < M_\text{P}$ as exhibited in the bottom panel which ensures that DBI-inflation is consistent with WGC.
+    We note that all the parameter points in the blue of the top left panel have $f < M_{Pl}$ as exhibited in the bottom panel which ensures that DBI-flation is consistent with WGC.
   } \label{fig:DBI}
 \end{figure}
 
@@ -755,27 +789,27 @@ The top right panel gives $f^{\text{equil}}_{\text{NL}}$ as function of $\alpha_
 Recently, the Planck Collaboration~\cite{Akrami:2019izv} has analyzed the Planck full-mission cosmic microwave background (CMB) temperature and E-mode polarization maps to obtain constraints on primordial non-Gaussianity.
 Their combined temperature and polarization analysis produces the following final result on $f^{\text{equil}}_{\text{NL}}$ so that $f^{\text{equal}}_{\text{NL}} = -26 \pm 47 \left(68 \% \text{CL, statistical}\right)$.
 We note that while the prediction of $f^{\text{equil}}_{\text{NL}}$ as given by the top right panel of Fig.~(\ref{fig:DBI}) is consistent with experiment, it is far too small to be tested in the near future.
-The bottom panel of Fig.~(\ref{fig:DBI}) gives a plot of $f_{eH} / M_\text{P}$ vs $f / M_\text{P}$.
-One finds that $f_{eH} / M_\text{P} \gg 1$ while $f / M_\text{P} < 1$ consistent with WGC.
+The bottom panel of Fig.~(\ref{fig:DBI}) gives a plot of $f_{eH} / M_{Pl}$ vs $f / M_{Pl}$.
+One finds that $f_{eH} / M_{Pl} \gg 1$ while $f / M_{Pl} < 1$ consistent with WGC.
 
 \section{Size of the tensor-to-scalar power spectra ratio $r$ in single-field models \label{sec:r}}
 It is interesting to observe that the tensor-to-scalar ratio $r$ in the effective single field models of global supersymmetry Fig.~(\ref{fig:supersymmetry}) and supergravity Fig.~(\ref{fig:supergravity}) is $O\left(10^{-4}\right)$, while for the DBI case Fig.~(\ref{fig:DBI}) it is much larger than that and for some parameter points it can be as large as the experimental upper limit $r \approx 0.1$.
 To see how this is possible, we consider first an arbitrary single-field inflation model with canonical kinetic energy.
 Here for the number of e-foldings we have
 \begin{equation} \label{eq:efoldingsGeneral}
-  N = \frac{1}{M_\text{P}} \int \sqrt{\rho / 3}\,dt
-    = \frac{1}{M_\text{P}} \int \sqrt{\rho / 3}\,\frac{d\phi}{\dot \phi}\,,
+  N = \frac{1}{M_{Pl}} \int \sqrt{\rho / 3}\,dt
+    = \frac{1}{M_{Pl}} \int \sqrt{\rho / 3}\,\frac{d\phi}{\dot \phi}\,,
 \end{equation}
 where $\rho$ is the density of the inflaton field $\phi$.
 In slow-roll approximation $\ddot \phi \approx 0$, and ${\dot \phi}^2 \ll V\left(\phi\right)$, and using equations of motion we have
 \begin{equation} \label{eq:efoldingsCanonical}
-  N = - \frac{1}{M_\text{P}^2} \int \frac{V\left(\phi\right)}{V^\prime\left(\phi\right)} d\phi
-    \approx - \frac{\Delta \phi}{M_\text{P} \sqrt{2 \epsilon}}\,,
+  N = - \frac{1}{M_{Pl}^2} \int \frac{V\left(\phi\right)}{V^\prime\left(\phi\right)} d\phi
+    \approx - \frac{\Delta \phi}{M_{Pl} \sqrt{2 \epsilon}}\,,
 \end{equation}
 where we used the definition of the slow-roll parameter $\epsilon$, see Eq.~(\ref{eq:epsEtaFromPotential}).
 This leads to a relation between $r$ and $\Delta \phi$ so that
 \begin{equation} \label{eq:Deltaphi}
-  r \approx \frac{8 \Delta\phi^2}{M_\text{P}^2 N^2}\,.
+  r \approx \frac{8 \Delta\phi^2}{M_{Pl}^2 N^2}\,.
 \end{equation}
 
 \begin{figure}
@@ -797,36 +831,55 @@ This leads to a relation between $r$ and $\Delta \phi$ so that
     Top right panel: Same as the left panel except it is for the supergravity case.
     Bottom panel: The same as the top left panel except it is for the DBI case.
     The figure explains the reason why $r$ can be much larger for DBI relative to models where slow roll is controlled by flat potentials.
-    From Eq.~(\ref{eq:rFromDDensityDN}) we see that $\epsilon_H$ and thus $r$ is proportional to $d\rho / dN$.
+    From Eq.~(\ref{eq:rFromDDensityr}) we see that $r$ is proportional to $d\rho / dN$.
     In the top panels $\rho / \rho_0$ is essentially flat near the horizon exist which is in the interval which occurs at $-60 < N - N_\text{total} < -50$ and leads to $r \sim O\left(10^{-4}\right)$ while for the DBI case in the bottom panel $\rho / \rho_0$ has a significant curvature and $r$ can be as large as $\sim 0.1$.
   } \label{fig:density}
 \end{figure}
-We consider now the global supersymmetry case where $\Delta\phi / f < 1$ and $f / M_\text{P} < 1$ (see Figs.~(\ref{fig:supersymmetry})) which implies
+We consider now the global supersymmetry case where $\Delta\phi / f < 1$ and $f / M_{Pl} < 1$ (see Figs.~(\ref{fig:supersymmetry})) which implies
 \begin{equation} \label{eq:rBound}
   r < 0.003\,.
 \end{equation}
 A similar analysis holds for the supergravity case.
 The analysis on $r$ in Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}) is consistent with the bound of Eq.~(\ref{eq:rBound}).
-The reason for the smallness of $r$ for Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}) and more generally for models with flat potentials can be traced to Eq.~(\ref{eq:Deltaphi}) and the condition $\Delta\phi < M_\text{P}$.
+The reason for the smallness of $r$ for Figs.~(\ref{fig:supersymmetry}, \ref{fig:supergravity}) and more generally for models with flat potentials can be traced to Eq.~(\ref{eq:Deltaphi}) and the condition $\Delta\phi < M_{Pl}$.
 
-However, Eq.~(\ref{eq:Deltaphi}) is not applicable to DBI-flation and k-flation.
+However, Eq.~(\ref{eq:Deltaphi}) is not applicable to DBI-flation and k-flation~\cite{Garriga:1999vw}
 Here we need to look at the evolution of the density $\rho$ of the inflaton field as a function of e-foldings.
-Thus for the case when sound velocity $c_s \sim 1$, $r$ can be approximated as follows
-\begin{equation} \label{eq:rFromDDensityDN}
-  r \approx 16 \epsilon_H
-          = - 16 \frac{\dot H}{H^2}
-          = - \frac{8 \sqrt{3} \dot\rho M_\text{P}}{\rho^{3 / 2}}
-          = - \frac{8}{\rho} \frac{d\rho}{dN}\,.
-\end{equation}
+\rr{Thus for the case when sound velocity $c_s \sim 1$, one can obtain the slow roll parameters in terms of density and
+its derivatives with respect to the number of e-foldings so that
+
+\begin{align}
+\epsilon_H&=-\frac{1}{2\rho} \frac{d\rho}{dN}\nonumber\\
+\eta_H&=  \frac{1}{\rho} \frac{d\rho}{dN}- \frac{d^2\rho}{dN^2}/\frac{d\rho}{dN}
+\end{align}
+Further, the enhancement factor $f_{eH}$ is given by 
+\begin{align}
+f_{eH}= M_{Pl}/\sqrt{2 \frac{\frac{d\rho}{dN}}{\rho} 
+- \frac{d^2\rho}{dN^2}/\frac{d\rho}{dN}}
+\end{align}
+Similarly the spectral index $n_s$ and the ratio $r$ of the tensor to scalar power spectrum are given by
+\begin{align}
+n_s&= 1+ \frac{2}{\rho} \frac{d\rho}{dN}- \frac{d^2\rho}{dN^2}/\frac{d\rho}{dN} \nonumber\\
+r&= - \frac{8}{\rho} \frac{d\rho}{dN}\,.
+\label{eq:rFromDDensityr}
+\end{align}
+
+
+
+}
+% $r$ can be approximated as follows
+
+%
+
+%\begin{equation} \label{eq:rFromDDensityDN}
+%  r \approx 16 \epsilon_H
+%          = - 16 \frac{\dot H}{H^2}
+%          = - \frac{128 \sqrt{3} \dot\rho M_{Pl}}{\rho^{3 / 2}}
+%          = - \frac{128}{\rho} \frac{d\rho}{dN}\,.
+%\end{equation}
 From the plot of $\rho / \rho_0$ as a function of $N - N_{\text{total}}$ one finds that $\frac{d\rho}{dN}$ is very small for the top panels of Fig.~(\ref{fig:density}) in the domain of horizon exit, i.e., $-60 < N - N_\text{total} < -50$ and leads to $r \sim O\left(10^{-4}\right)$.
 On the other hand for the DBI case $\frac{d\rho}{dN}$ is visibly much larger as can be seen by the bottom panel of Fig.~(\ref{fig:density}).
 This explains why $r$ is much larger for the DBI case than for the case where inflation is driven by the potential which is the case for the top panels of Fig.~(\ref{fig:density}).
-
-It is possible to express $\eta_H$ and $f_{eH}$ in terms of density as well so that
-\begin{align}
-  \eta_H = \frac{d\rho / dN}{\rho} - \frac{d^2\rho / \left(dN\right)^2}{d\rho / dN}\,,\\
-  f_{eH} = M_\text{P} \left/ \sqrt{2 \frac{d\rho / dN}{\rho} - \frac{d^2\rho / \left(dN\right)^2}{d\rho / dN}} \right.\,.
-\end{align}
 
 \section{Conclusion \label{sec:Conclusion}}
 One of the possible candidates for an inflaton is an axion.
@@ -848,6 +901,7 @@ We also show that the effective decay constant can be directly related to the sp
 The analysis presented in this work shows that in all the cases considered axion inflation consistent with the experimental data can be accomplished with the axion decay constant in the microscopic Lagrangian in the sub-Planckian domain in conformity with the Weak Gravity Conjecture.\\~\\~\\
 
 \textbf{Acknowledgments:}
+\rr{Conversations with James Halverson and Cody Long are acknowledged.}
 This research was supported in part by the NSF Grant PHY-1620575.
 
 \clearpage

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -127,7 +127,7 @@ italicLabel[l_] := "\(\*StyleBox[\"" <> l <> "\", FontSlant -> \"Italic\"]\)"
 subscriptLabel[m_, s_] := "\(\*SubscriptBox[" <> m <> ", " <> s <> "]\)"
 rowLabel[el_List] := "\(\*RowBox[{" <> StringRiffle[el, ", "] <> "}]\)"
 ratioLabel[l1_, l2_] := rowLabel[{l1, "\"/\"", l2}]
-planckMassLabel = subscriptLabel[italicLabel["M"], plainLabel["P"]];
+planckMassLabel = subscriptLabel[italicLabel["M"], italicLabel["Pl"]];
 label[x_] := traditionalLabel[If[Head[$label[x]] === $label, x, $label[x]]]
 
 

--- a/computeSimulations.wls
+++ b/computeSimulations.wls
@@ -419,7 +419,7 @@ evaluateModel[<|
 		"where $\\mathcal{U}$ refers to a uniform distribution. " <>
 		"We set $B = 1$, as it only affects the time scale of inflation, but not " <>
 		"the values of $n_s$, $r$, and $f_e$. " <>
-		"Finally, $f / M_\\text{P} \\sim <*distribution[\"f\"]*>$, " <>
+		"Finally, $f / M_{Pl} \\sim <*distribution[\"f\"]*>$, " <>
 		"$b_{-, \\text{init}} / f \\sim <*distribution[\"fieldInitialOverF\"]*>$, " <>
 		"$N_\\text{pivot} \\sim <*distribution[\"pivotEfoldings\"]*>$."|>];
 
@@ -472,7 +472,7 @@ evaluateModel[<|
 		"Here $A_1 = 1$, " <>
 		"$A_2 \\sim <*distribution[\"A2\", {4, 3}]*>$, " <>
 		"$A_3 \\sim <*distribution[\"A3\", {5, 4}]*>$, " <>
-		"$f / M_\\text{P} \\sim <*distribution[\"f\"]*>$, " <>
+		"$f / M_{Pl} \\sim <*distribution[\"f\"]*>$, " <>
 		"$b_{-, \\text{init}} / f \\sim <*distribution[\"fieldInitialOverF\"]*>$, " <>
 		"$N_\\text{pivot} \\sim <*distribution[\"pivotEfoldings\"]*>$."|>];
 
@@ -578,8 +578,8 @@ dbiSpecs = <|
 		"are consistent with experimental data on $r$ and $n_s$. " <>
 		"Points are distributed according to the following: " <>
 		"$\\alpha_1 \\sim X_{0, \\infty}$, " <>
-		"$T = 10^{-12} M_\\text{P}^4$, " <>
-		"$f \\sim X_{0, \\infty} M_\\text{P}$, " <>
+		"$T = 10^{-12} M_{Pl}^4$, " <>
+		"$f \\sim X_{0, \\infty} M_{Pl}$, " <>
 		"$\\tilde\\beta \\sim X_{0, \\infty}$, " <>
 		"$m = 6$, " <>
 		"${\\cal{G}}_1 = {\\cal{G}}_2 = {\\cal{G}}_3 = 0$, ${\\cal{G}}_4 = 1$, " <>
@@ -598,7 +598,7 @@ dbiSpecs = <|
 		"the expression under the square root in Eq.~(\\ref{eq:dbi:lagrangian}) " <>
 		"is positive. " <>
 		"Points are further filtered such that " <>
-		"the mass of the inflaton $m_{a_-} < 0.1 M_\\text{P}$. " <>
+		"the mass of the inflaton $m_{a_-} < 0.1 M_{Pl}$. " <>
 		"Note that despite no fine-tuning being present in the distribution above, " <>
 		"a significant fraction of points is consistent with " <>
 		"experimental constraints."|>;


### PR DESCRIPTION
## Changes
@Born-infeld 
* Changes `M_\text{P}` to `M_{Pl}` everywhere in the text.
* Rewording of some text

@maxitg 
* Changes `M_\text{P}` to `M_{Pl}` in figures and figure captions.
* Fix wrong sign in the definition of `$\eta_H$` and cascading mistakes that caused in the equations for `$f_{eH}$` in terms of density.
<img width="490" alt="Screen Shot 2019-06-04 at 22 13 47" src="https://user-images.githubusercontent.com/1479325/58927902-06863600-8716-11e9-8569-7e02d444e149.png">
* Closes #66:

[feHFromdRhodN.nb.zip](https://github.com/maxitg/coherent-enhancement/files/3255381/feHFromdRhodN.nb.zip)